### PR TITLE
Fixed a two properties of Manager

### DIFF
--- a/dist/structures/Manager.d.ts
+++ b/dist/structures/Manager.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import Collection from "@discordjs/collection";
+import { Collection } from "@discordjs/collection";
 import { EventEmitter } from "events";
 import { VoiceState } from "..";
 import { Node, NodeOptions } from "./Node";
@@ -132,9 +132,9 @@ export declare class Manager extends EventEmitter {
     /** Object of Link Regexes */
     static readonly regex : regexObject;
     /** The map of players. */
-    readonly players: Collection<string, Player>;
+    readonly players = new Collection<string, Player>();
     /** The map of nodes. */
-    readonly nodes: Collection<string, Node>;
+    readonly nodes = new Collection<string, Node>();
     /** The options that were set. */
     readonly options: ManagerOptions;
     /** Array of valid links; */


### PR DESCRIPTION
Analyzing the erela.js of MenuDocs I found a pretty big change, which is the properties of player and nodes, which _should_ be a collection, and not assigning nodes Collection as a property, this change allows the collection to return an array or whatever is needed from those objects.

As an example I use the nodes one to check the nodes and see which node is down and which is not, which I need to return the collection as an arraylist.