### PR TITLE
Update Utils.js

### DIFF
--- a/dist/structures/Utils.js
+++ b/dist/structures/Utils.js
@@ -104,7 +104,7 @@ class TrackUtils {
                         typeof data.info.image === "string" ?
                             data.info.image :
                             ["youtube.", "youtu.be"].some(d => data.info.uri?.includes?.(d)) ?
-                                `https://img.youtube.com/vi/${data.info.identifier}/mqdefault.jpg`
+                                `https://img.youtube.com/vi/${data.info.identifier}/maxresdefault.jpg`
                                 : (data.info?.md5_image && data.info?.uri?.includes?.("deezer"))
                                     ? `https://cdns-images.dzcdn.net/images/cover/${data.info.md5_image}/500x500.jpg`
                                     : null,
@@ -119,7 +119,7 @@ class TrackUtils {
                         typeof data.info.image === "string" ?
                             data.info.image :
                             ["youtube.", "youtu.be"].some(d => data.info.uri?.includes?.(d)) ?
-                                `https://img.youtube.com/vi/${data.info.identifier}/mqdefault.jpg`
+                                `https://img.youtube.com/vi/${data.info.identifier}/maxresdefault.jpg`
                                 : (data.info?.md5_image && data.info?.uri?.includes?.("deezer"))
                                     ? `https://cdns-images.dzcdn.net/images/cover/${data.info.md5_image}/500x500.jpg`
                                     : null,

--- a/src/structures/Utils.ts
+++ b/src/structures/Utils.ts
@@ -112,7 +112,7 @@ export abstract class TrackUtils {
             typeof data.info.image === "string" ?
               data.info.image :
               ["youtube.", "youtu.be"].some(d => data.info.uri?.includes?.(d)) ?
-                `https://img.youtube.com/vi/${data.info.identifier}/mqdefault.jpg`
+                `https://img.youtube.com/vi/${data.info.identifier}/maxresdefault.jpg`
                 : (data.info?.md5_image && data.info?.uri?.includes?.("deezer"))
                   ? `https://cdns-images.dzcdn.net/images/cover/${data.info.md5_image}/500x500.jpg`
                   : null,
@@ -127,7 +127,7 @@ export abstract class TrackUtils {
             typeof data.info.image === "string" ? 
                 data.info.image :
                 ["youtube.", "youtu.be"].some(d => data.info.uri?.includes?.(d)) ?
-                    `https://img.youtube.com/vi/${data.info.identifier}/mqdefault.jpg`
+                    `https://img.youtube.com/vi/${data.info.identifier}/maxresdefault.jpg`
                     : (data.info?.md5_image && data.info?.uri?.includes?.("deezer"))
                         ? `https://cdns-images.dzcdn.net/images/cover/${data.info.md5_image}/500x500.jpg`
                         : null,


### PR DESCRIPTION
Choosing 'maxresdefault' as the Youtube thumbnail due to the removal of the displayThumbnail function.
Just a option as displayThumbnail is deleted.