### PR TITLE
Change Requester type and add ManagerEvents Interface

### DIFF
--- a/dist/structures/Manager.d.ts
+++ b/dist/structures/Manager.d.ts
@@ -4,8 +4,7 @@ import { EventEmitter } from "node:events";
 import { VoiceState } from "..";
 import { Node, NodeOptions } from "./Node";
 import { Player, PlayerOptions, Track, UnresolvedTrack } from "./Player";
-import { PluginDataInfo, v4LoadType } from "./Utils";
-import { LoadType, Plugin, TrackData, TrackEndEvent, TrackExceptionEvent, TrackStartEvent, TrackStuckEvent, VoicePacket, VoiceServer, WebSocketClosedEvent } from "./Utils";
+import { LoadType, Plugin, PluginDataInfo, TrackData, TrackEndEvent, TrackExceptionEvent, TrackStartEvent, TrackStuckEvent, VoicePacket, VoiceServer, WebSocketClosedEvent, v4LoadType } from "./Utils";
 export declare const v4LoadTypes: {
     TrackLoaded: string;
     PlaylistLoaded: string;
@@ -14,95 +13,101 @@ export declare const v4LoadTypes: {
     LoadFailed: string;
 };
 export declare const LoadTypes: Record<"TrackLoaded" | "PlaylistLoaded" | "SearchResult" | "NoMatches" | "LoadFailed", LoadType>;
-export interface Manager {
+export interface ManagerEvents {
     /**
      * Emitted when a Node is created.
      * @event Manager#nodeCreate
      */
-    on(event: "nodeCreate", listener: (node: Node) => void): this;
+    nodeCreate: (node: Node) => void;
     /**
      * Emitted when a Node is destroyed.
      * @event Manager#nodeDestroy
      */
-    on(event: "nodeDestroy", listener: (node: Node) => void): this;
+    nodeDestroy: (node: Node) => void;
     /**
      * Emitted when a Node connects.
      * @event Manager#nodeConnect
      */
-    on(event: "nodeConnect", listener: (node: Node) => void): this;
+    nodeConnect: (node: Node) => void;
     /**
      * Emitted when a Node reconnects.
      * @event Manager#nodeReconnect
      */
-    on(event: "nodeReconnect", listener: (node: Node) => void): this;
+    nodeReconnect: (node: Node) => void;
     /**
      * Emitted when a Node disconnects.
      * @event Manager#nodeDisconnect
      */
-    on(event: "nodeDisconnect", listener: (node: Node, reason: {
+    nodeDisconnect: (node: Node, reason: {
         code?: number;
         reason?: string;
-    }) => void): this;
+    }) => void;
     /**
      * Emitted when a Node has an error.
      * @event Manager#nodeError
      */
-    on(event: "nodeError", listener: (node: Node, error: Error) => void): this;
+    nodeError: (node: Node, error: Error) => void;
     /**
      * Emitted whenever any Lavalink event is received.
      * @event Manager#nodeRaw
      */
-    on(event: "nodeRaw", listener: (payload: unknown) => void): this;
+    nodeRaw: (payload: unknown) => void;
     /**
      * Emitted when a player is created.
      * @event Manager#playerCreate
      */
-    on(event: "playerCreate", listener: (player: Player) => void): this;
+    playerCreate: (player: Player) => void;
     /**
      * Emitted when a player is destroyed.
      * @event Manager#playerDestroy
      */
-    on(event: "playerDestroy", listener: (player: Player) => void): this;
+    playerDestroy: (player: Player) => void;
     /**
      * Emitted when a player queue ends.
      * @event Manager#queueEnd
      */
-    on(event: "queueEnd", listener: (player: Player, track: Track | UnresolvedTrack, payload: TrackEndEvent) => void): this;
+    queueEnd: (player: Player, track: Track | UnresolvedTrack, payload: TrackEndEvent) => void;
     /**
      * Emitted when a player is moved to a new voice channel.
      * @event Manager#playerMove
      */
-    on(event: "playerMove", listener: (player: Player, initChannel: string, newChannel: string) => void): this;
+    playerMove: (player: Player, initChannel: string, newChannel: string) => void;
     /**
      * Emitted when a player is disconnected from it's current voice channel.
      * @event Manager#playerDisconnect
      */
-    on(event: "playerDisconnect", listener: (player: Player, oldChannel: string) => void): this;
+    playerDisconnect: (player: Player, oldChannel: string) => void;
     /**
      * Emitted when a track starts.
      * @event Manager#trackStart
      */
-    on(event: "trackStart", listener: (player: Player, track: Track, payload: TrackStartEvent) => void): this;
+    trackStart: (player: Player, track: Track, payload: TrackStartEvent) => void;
     /**
      * Emitted when a track ends.
      * @event Manager#trackEnd
      */
-    on(event: "trackEnd", listener: (player: Player, track: Track, payload: TrackEndEvent) => void): this;
+    trackEnd: (player: Player, track: Track, payload: TrackEndEvent) => void;
     /**
      * Emitted when a track gets stuck during playback.
      * @event Manager#trackStuck
      */
-    on(event: "trackStuck", listener: (player: Player, track: Track, payload: TrackStuckEvent) => void): this;
+    trackStuck: (player: Player, track: Track, payload: TrackStuckEvent) => void;
     /**
      * Emitted when a track has an error during playback.
      * @event Manager#trackError
      */
-    on(event: "trackError", listener: (player: Player, track: Track | UnresolvedTrack, payload: TrackExceptionEvent) => void): this;
+    trackError: (player: Player, track: Track | UnresolvedTrack, payload: TrackExceptionEvent) => void;
     /**
      * Emitted when a voice connection is closed.
      * @event Manager#socketClosed
      */
-    on(event: "socketClosed", listener: (player: Player, payload: WebSocketClosedEvent) => void): this;
+    socketClosed: (player: Player, payload: WebSocketClosedEvent) => void;
+}
+export interface Manager {
+    on<K extends keyof ManagerEvents>(event: K, listener: ManagerEvents[K]): this;
+    once<K extends keyof ManagerEvents>(event: K, listener: ManagerEvents[K]): this;
+    emit<K extends keyof ManagerEvents>(event: K, ...args: Parameters<ManagerEvents[K]>): boolean;
+    off<K extends keyof ManagerEvents>(event: K, listener: ManagerEvents[K]): this;
 }
 /**
  * The main hub for interacting with Lavalink and using Erela.JS,
@@ -160,12 +165,12 @@ export declare class Manager extends EventEmitter {
      */
     search(query: string | SearchQuery, requester?: unknown, customNode?: Node): Promise<SearchResult>;
     /**
-       * Searches the a link directly without any source
-       * @param query
-       * @param requester
-       * @param customNode
-       * @returns The search result.
-       */
+     * Searches the a link directly without any source
+     * @param query
+     * @param requester
+     * @param customNode
+     * @returns The search result.
+     */
     searchLink(query: string | SearchQuery, requester?: unknown, customNode?: Node): Promise<SearchResult>;
     validatedQuery(queryString: string, node: Node): void;
     /**

--- a/dist/structures/Manager.js
+++ b/dist/structures/Manager.js
@@ -18,60 +18,90 @@ exports.LoadTypes = {
     PlaylistLoaded: "PLAYLIST_LOADED",
     SearchResult: "SEARCH_RESULT",
     NoMatches: "NO_MATCHES",
-    LoadFailed: "LOAD_FAILED"
+    LoadFailed: "LOAD_FAILED",
 };
 function check(options) {
     if (!options)
         throw new TypeError("ManagerOptions must not be empty.");
     if (typeof options.send !== "function")
         throw new TypeError('Manager option "send" must be present and a function.');
-    if (typeof options.clientId !== "undefined" && !/^\d+$/.test(options.clientId))
+    if (typeof options.clientId !== "undefined" &&
+        !/^\d+$/.test(options.clientId))
         throw new TypeError('Manager option "clientId" must be a non-empty string.');
     if (typeof options.nodes !== "undefined" && !Array.isArray(options.nodes))
         throw new TypeError('Manager option "nodes" must be a array.');
-    if (typeof options.shards !== "undefined" && typeof options.shards !== "number")
+    if (typeof options.shards !== "undefined" &&
+        typeof options.shards !== "number")
         throw new TypeError('Manager option "shards" must be a number.');
     if (typeof options.plugins !== "undefined" && !Array.isArray(options.plugins))
         throw new TypeError('Manager option "plugins" must be a Plugin array.');
-    if (typeof options.autoPlay !== "undefined" && typeof options.autoPlay !== "boolean")
+    if (typeof options.autoPlay !== "undefined" &&
+        typeof options.autoPlay !== "boolean")
         throw new TypeError('Manager option "autoPlay" must be a boolean.');
-    if (typeof options.trackPartial !== "undefined" && !Array.isArray(options.trackPartial))
+    if (typeof options.trackPartial !== "undefined" &&
+        !Array.isArray(options.trackPartial))
         throw new TypeError('Manager option "trackPartial" must be a string array.');
-    if (typeof options.clientName !== "undefined" && typeof options.clientName !== "string")
+    if (typeof options.clientName !== "undefined" &&
+        typeof options.clientName !== "string")
         throw new TypeError('Manager option "clientName" must be a string.');
-    if (typeof options.defaultSearchPlatform !== "undefined" && typeof options.defaultSearchPlatform !== "string")
+    if (typeof options.defaultSearchPlatform !== "undefined" &&
+        typeof options.defaultSearchPlatform !== "string")
         throw new TypeError('Manager option "defaultSearchPlatform" must be a string.');
-    if (typeof options.volumeDecrementer !== "undefined" && (typeof options.volumeDecrementer !== "number" || isNaN(options.volumeDecrementer)))
+    if (typeof options.volumeDecrementer !== "undefined" &&
+        (typeof options.volumeDecrementer !== "number" ||
+            isNaN(options.volumeDecrementer)))
         throw new TypeError('Manager option "volumeDecrementer" must be a number between 0 and 1.');
     if (options.volumeDecrementer > 1 || options.volumeDecrementer < 0)
         throw new TypeError('Manager option "volumeDecrementer" must be a number between 0 and 1.');
-    if (typeof options.position_update_interval !== "undefined" && (typeof options.position_update_interval !== "number" || isNaN(options.position_update_interval)))
+    if (typeof options.position_update_interval !== "undefined" &&
+        (typeof options.position_update_interval !== "number" ||
+            isNaN(options.position_update_interval)))
         throw new TypeError('Manager option "position_update_interval" must be a number between 50 and 1000., set it to 0 to disable it');
-    if ((options.position_update_interval > 1000 || options.position_update_interval < 50) && options.position_update_interval !== 0)
+    if ((options.position_update_interval > 1000 ||
+        options.position_update_interval < 50) &&
+        options.position_update_interval !== 0)
         throw new TypeError('Manager option "position_update_interval" must be a number between 50 and 1000., set it to 0 to disable it');
-    if (typeof options.validUnresolvedUris !== "undefined" && !Array.isArray(options.validUnresolvedUris) && !options.validUnresolvedUris.every(v => typeof v === "string"))
+    if (typeof options.validUnresolvedUris !== "undefined" &&
+        !Array.isArray(options.validUnresolvedUris) &&
+        !options.validUnresolvedUris.every((v) => typeof v === "string"))
         throw new TypeError('Manager option "validUnresolvedUris" must be an array of strings');
-    if (typeof options.forceLoadPlugin !== "undefined" && typeof options.forceLoadPlugin !== "boolean")
+    if (typeof options.forceLoadPlugin !== "undefined" &&
+        typeof options.forceLoadPlugin !== "boolean")
         throw new TypeError('Manager option "forceLoadPlugin" must be a boolean');
-    if (typeof options.allowedLinks !== "undefined" && !Array.isArray(options.allowedLinks) && !options.allowedLinks.every(v => typeof v === "string"))
+    if (typeof options.allowedLinks !== "undefined" &&
+        !Array.isArray(options.allowedLinks) &&
+        !options.allowedLinks.every((v) => typeof v === "string"))
         throw new TypeError('Manager option "allowedLinks" must be an array of strings');
-    if (typeof options.allowedLinksRegexes !== "undefined" && !Array.isArray(options.allowedLinksRegexes) && !options.allowedLinksRegexes.every(v => v instanceof RegExp))
+    if (typeof options.allowedLinksRegexes !== "undefined" &&
+        !Array.isArray(options.allowedLinksRegexes) &&
+        !options.allowedLinksRegexes.every((v) => v instanceof RegExp))
         throw new TypeError('Manager option "allowedLinksRegexes" must be an array of regexes');
-    if (typeof options.onlyAllowAllowedLinks !== "undefined" && typeof options.onlyAllowAllowedLinks !== "boolean")
+    if (typeof options.onlyAllowAllowedLinks !== "undefined" &&
+        typeof options.onlyAllowAllowedLinks !== "boolean")
         throw new TypeError('Manager option "onlyAllowAllowedLinks" must be a boolean');
-    if (typeof options.defaultLeastUsedNodeSortType !== "undefined" && options.defaultLeastUsedNodeSortType !== "memory" && options.defaultLeastUsedNodeSortType !== "calls" && options.defaultLeastUsedNodeSortType !== "players")
+    if (typeof options.defaultLeastUsedNodeSortType !== "undefined" &&
+        options.defaultLeastUsedNodeSortType !== "memory" &&
+        options.defaultLeastUsedNodeSortType !== "calls" &&
+        options.defaultLeastUsedNodeSortType !== "players")
         throw new TypeError('Manager option "defaultLeastUsedNodeSortType" must be a string of leastUsedNodeSortType ("memory" | "calls" | "players")');
-    if (typeof options.defaultLeastLoadNodeSortType !== "undefined" && options.defaultLeastLoadNodeSortType !== "cpu" && options.defaultLeastLoadNodeSortType !== "memory")
+    if (typeof options.defaultLeastLoadNodeSortType !== "undefined" &&
+        options.defaultLeastLoadNodeSortType !== "cpu" &&
+        options.defaultLeastLoadNodeSortType !== "memory")
         throw new TypeError('Manager option "defaultLeastLoadNodeSortType" must be a string of leastUsedNodeSortType ("cpu" | "memory")');
-    if (typeof options.useUnresolvedData !== "undefined" && typeof options.useUnresolvedData !== "boolean")
+    if (typeof options.useUnresolvedData !== "undefined" &&
+        typeof options.useUnresolvedData !== "boolean")
         throw new TypeError('Manager option "useUnresolvedData" must be a boolean');
-    if (typeof options.forceSearchLinkQueries !== "undefined" && typeof options.forceSearchLinkQueries !== "boolean")
+    if (typeof options.forceSearchLinkQueries !== "undefined" &&
+        typeof options.forceSearchLinkQueries !== "boolean")
         throw new TypeError('Manager option "forceSearchLinkQueries" must be a boolean');
-    if (typeof options.userAgent !== "undefined" && typeof options.userAgent !== "string")
+    if (typeof options.userAgent !== "undefined" &&
+        typeof options.userAgent !== "string")
         throw new TypeError('Manager option "userAgent" must be a string (public useragent when doing fetch requests)');
-    if (typeof options.restTimeout !== "undefined" && (typeof options.restTimeout !== "number" || isNaN(options.restTimeout)))
+    if (typeof options.restTimeout !== "undefined" &&
+        (typeof options.restTimeout !== "number" || isNaN(options.restTimeout)))
         throw new TypeError('Manager option "restTimeout" must be a number');
-    if (typeof options.applyVolumeAsFilter !== "undefined" && typeof options.applyVolumeAsFilter !== "boolean")
+    if (typeof options.applyVolumeAsFilter !== "undefined" &&
+        typeof options.applyVolumeAsFilter !== "boolean")
         throw new TypeError('Manager option "applyVolumeAsFilter" must be a boolean');
 }
 /**
@@ -82,37 +112,37 @@ class Manager extends node_events_1.EventEmitter {
     static DEFAULT_SOURCES = {
         // youtubemusic
         "youtube music": "ytmsearch",
-        "ytmsearch": "ytmsearch",
-        "ytm": "ytmsearch",
+        ytmsearch: "ytmsearch",
+        ytm: "ytmsearch",
         // youtube
-        "youtube": "ytsearch",
-        "yt": "ytsearch",
-        "ytsearch": "ytsearch",
+        youtube: "ytsearch",
+        yt: "ytsearch",
+        ytsearch: "ytsearch",
         // soundcloud
-        "soundcloud": "scsearch",
-        "scsearch": "scsearch",
-        "sc": "scsearch",
+        soundcloud: "scsearch",
+        scsearch: "scsearch",
+        sc: "scsearch",
         // apple music
-        "amsearch": "amsearch",
-        "am": "amsearch",
-        // spotify 
-        "spsearch": "spsearch",
-        "sp": "spsearch",
-        "sprec": "sprec",
-        "spsuggestion": "sprec",
+        amsearch: "amsearch",
+        am: "amsearch",
+        // spotify
+        spsearch: "spsearch",
+        sp: "spsearch",
+        sprec: "sprec",
+        spsuggestion: "sprec",
         // deezer
-        "dz": "dzsearch",
-        "deezer": "dzsearch",
-        "ds": "dzsearch",
-        "dzsearch": "dzsearch",
-        "dzisrc": "dzisrc",
+        dz: "dzsearch",
+        deezer: "dzsearch",
+        ds: "dzsearch",
+        dzsearch: "dzsearch",
+        dzisrc: "dzisrc",
         // yandexmusic
-        "yandexmusic": "ymsearch",
-        "yandex": "ymsearch",
-        "ymsearch": "ymsearch",
+        yandexmusic: "ymsearch",
+        yandex: "ymsearch",
+        ymsearch: "ymsearch",
         // speak
-        "speak": "speak",
-        "tts": "tts",
+        speak: "speak",
+        tts: "tts",
     };
     static regex = {
         YoutubeRegex: /https?:\/\/?(?:www\.)?(?:(m|www)\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|shorts|playlist\?|watch\?v=|watch\?.+(?:&|&#38;);v=))([a-zA-Z0-9\-_]{11})?(?:(?:\?|&|&#38;)index=((?:\d){1,3}))?(?:(?:\?|&|&#38;)?list=([a-zA-Z\-_0-9]{34}))?(?:\S+)?/,
@@ -198,12 +228,8 @@ class Manager extends node_events_1.EventEmitter {
         return this.nodes
             .filter((node) => node.connected)
             .sort((a, b) => {
-            const aload = a.stats.memory?.used
-                ? a.stats.memory.used
-                : 0;
-            const bload = b.stats.memory?.used
-                ? b.stats.memory.used
-                : 0;
+            const aload = a.stats.memory?.used ? a.stats.memory.used : 0;
+            const bload = b.stats.memory?.used ? b.stats.memory.used : 0;
             return aload - bload;
         });
     }
@@ -230,7 +256,10 @@ class Manager extends node_events_1.EventEmitter {
         for (const arg of args) {
             try {
                 url = new URL(arg);
-                url = url.protocol === "http:" || url.protocol === "https:" ? url.href : false;
+                url =
+                    url.protocol === "http:" || url.protocol === "https:"
+                        ? url.href
+                        : false;
                 break;
             }
             catch (_) {
@@ -255,7 +284,8 @@ class Manager extends node_events_1.EventEmitter {
         }
         this.options = {
             plugins: [],
-            nodes: [{
+            nodes: [
+                {
                     identifier: "default",
                     host: "localhost",
                     port: 2333,
@@ -266,7 +296,8 @@ class Manager extends node_events_1.EventEmitter {
                     requestTimeout: 10e3,
                     version: "v3",
                     useVersionPath: true, // should be set on true, to use the latest rest api correctly!
-                }],
+                },
+            ],
             shards: 1,
             autoPlay: true,
             clientName: "erela.js",
@@ -311,7 +342,8 @@ class Manager extends node_events_1.EventEmitter {
         if (typeof clientId !== "undefined")
             this.options.clientId = clientId;
         if (typeof clientName !== "undefined")
-            this.options.clientName = clientName || `Unknown Name - ${clientId || clientID}`;
+            this.options.clientName =
+                clientName || `Unknown Name - ${clientId || clientID}`;
         if (typeof shards !== "undefined")
             this.options.shards = shards;
         if (typeof this.options.clientId !== "string")
@@ -340,21 +372,29 @@ class Manager extends node_events_1.EventEmitter {
             const node = customNode || this.leastUsedNodes.first();
             if (!node)
                 throw new Error("No available nodes.");
-            const res = await node.makeRequest(`/loadtracks?identifier=${query}`);
+            const res = (await node.makeRequest(`/loadtracks?identifier=${query}`));
             if (!res)
                 return reject(new Error("Query not found."));
-            const dataArray = ([exports.v4LoadTypes.LoadFailed, exports.v4LoadTypes.NoMatches, exports.LoadTypes.LoadFailed, exports.LoadTypes.NoMatches].includes(res.loadType)
+            const dataArray = ([
+                exports.v4LoadTypes.LoadFailed,
+                exports.v4LoadTypes.NoMatches,
+                exports.LoadTypes.LoadFailed,
+                exports.LoadTypes.NoMatches,
+            ].includes(res.loadType)
                 ? [] // error / No matches
                 : res.loadType === exports.v4LoadTypes.PlaylistLoaded
                     ? res.data.tracks // playlist
-                    : res?.[node.options?.version === "v4" ? "data" : "tracks"] && !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"])
+                    : res?.[node.options?.version === "v4" ? "data" : "tracks"] &&
+                        !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"])
                         ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]]
                         : res?.[node.options?.version === "v4" ? "data" : "tracks"])?.filter(Boolean);
             const result = {
                 loadType: res.loadType,
                 pluginInfo: res.pluginInfo || res?.data?.pluginInfo,
                 exception: res.exception ?? null,
-                tracks: dataArray?.length ? dataArray?.map((track) => Utils_1.TrackUtils.build(track, requester)) : [],
+                tracks: dataArray?.length
+                    ? dataArray?.map((track) => Utils_1.TrackUtils.build(track, requester))
+                    : [],
             };
             this.applyPlaylistInfo(result, res, node);
             return resolve(result);
@@ -362,27 +402,48 @@ class Manager extends node_events_1.EventEmitter {
     }
     applyPlaylistInfo(result, res, node) {
         // v4
-        if (node.options?.version === "v4" && result.loadType === exports.v4LoadTypes.PlaylistLoaded) {
-            const selectedTrack = typeof res.data?.info?.selectedTrack !== "number" || res.data?.info?.selectedTrack === -1 ? null : result.tracks[res.data?.info?.selectedTrack];
+        if (node.options?.version === "v4" &&
+            result.loadType === exports.v4LoadTypes.PlaylistLoaded) {
+            const selectedTrack = typeof res.data?.info?.selectedTrack !== "number" ||
+                res.data?.info?.selectedTrack === -1
+                ? null
+                : result.tracks[res.data?.info?.selectedTrack];
             result.playlist = {
                 name: res.data.info?.name || res.data.pluginInfo?.name || null,
                 author: res.data.info?.author || res.data.pluginInfo?.author || null,
-                thumbnail: res.data.info?.artworkUrl || res.data.pluginInfo?.artworkUrl || selectedTrack?.thumbnail || null,
-                uri: res.data.info?.url || res.data.info?.uri || res.data.info?.link || res.data.pluginInfo?.url || res.data.pluginInfo?.uri || res.data.pluginInfo?.link || null,
+                thumbnail: res.data.info?.artworkUrl ||
+                    res.data.pluginInfo?.artworkUrl ||
+                    selectedTrack?.thumbnail ||
+                    null,
+                uri: res.data.info?.url ||
+                    res.data.info?.uri ||
+                    res.data.info?.link ||
+                    res.data.pluginInfo?.url ||
+                    res.data.pluginInfo?.uri ||
+                    res.data.pluginInfo?.link ||
+                    null,
                 selectedTrack: selectedTrack,
                 duration: result.tracks.reduce((acc, cur) => acc + (cur?.duration || 0), 0),
             };
         }
-        else if (result.loadType === exports.LoadTypes.PlaylistLoaded || result.loadType === exports.v4LoadTypes.PlaylistLoaded) { // v3 / v2
+        else if (result.loadType === exports.LoadTypes.PlaylistLoaded ||
+            result.loadType === exports.v4LoadTypes.PlaylistLoaded) {
+            // v3 / v2
             if (typeof res.playlistInfo === "object") {
-                const selectedTrack = typeof res.playlistInfo?.selectedTrack !== "number" || res.playlistInfo?.selectedTrack === -1 ? null : result.tracks[res.playlistInfo?.selectedTrack];
+                const selectedTrack = typeof res.playlistInfo?.selectedTrack !== "number" ||
+                    res.playlistInfo?.selectedTrack === -1
+                    ? null
+                    : result.tracks[res.playlistInfo?.selectedTrack];
                 result.playlist = {
                     ...res.playlistInfo,
                     // transform other Data(s)
                     name: res.playlistInfo.name || null,
                     author: res.playlistInfo.author || null,
                     thumbnail: selectedTrack?.thumbnail || null,
-                    uri: res.playlistInfo?.url || res.playlistInfo?.uri || res.playlistInfo?.link || null,
+                    uri: res.playlistInfo?.url ||
+                        res.playlistInfo?.uri ||
+                        res.playlistInfo?.link ||
+                        null,
                     selectedTrack: selectedTrack,
                     duration: result.tracks.reduce((acc, cur) => acc + (cur.duration || 0), 0),
                 };
@@ -402,47 +463,64 @@ class Manager extends node_events_1.EventEmitter {
             if (!node)
                 throw new Error("No available nodes.");
             const _query = typeof query === "string" ? { query } : query;
-            const _source = Manager.DEFAULT_SOURCES[_query.source ?? this.options.defaultSearchPlatform] ?? _query.source ?? this.options.defaultSearchPlatform;
+            const _source = Manager.DEFAULT_SOURCES[_query.source ?? this.options.defaultSearchPlatform] ??
+                _query.source ??
+                this.options.defaultSearchPlatform;
             _query.query = _query?.query?.trim?.();
             const link = this.getValidUrlOfQuery(_query.query);
-            if (this.options.allowedLinksRegexes?.length || this.options.allowedLinks?.length) {
-                if (link && !this.options.allowedLinksRegexes?.some(regex => regex.test(link)) && !this.options.allowedLinks?.includes(link))
+            if (this.options.allowedLinksRegexes?.length ||
+                this.options.allowedLinks?.length) {
+                if (link &&
+                    !this.options.allowedLinksRegexes?.some((regex) => regex.test(link)) &&
+                    !this.options.allowedLinks?.includes(link))
                     reject(new Error(`Query ${_query.query} Contains link: ${link}, which is not an allowed / valid Link`));
             }
             if (link && this.options.forceSearchLinkQueries)
-                return await this.searchLink(link, requester, customNode).then(data => resolve(data)).catch(err => reject(err));
-            // only set the source, if it's not a link 
+                return await this.searchLink(link, requester, customNode)
+                    .then((data) => resolve(data))
+                    .catch((err) => reject(err));
+            // only set the source, if it's not a link
             const srcSearch = !/^https?:\/\//.test(_query.query) ? `${_source}:` : "";
             this.validatedQuery(`${srcSearch}${_query.query}`, node);
-            const res = await node
+            const res = (await node
                 .makeRequest(`/loadtracks?identifier=${srcSearch}${encodeURIComponent(_query.query)}`)
-                .catch(err => reject(err));
+                .catch((err) => reject(err)));
             if (!res)
                 return reject(new Error("Query not found."));
-            const dataArray = ([exports.v4LoadTypes.LoadFailed, exports.v4LoadTypes.NoMatches, exports.LoadTypes.LoadFailed, exports.LoadTypes.NoMatches].includes(res.loadType)
+            const dataArray = ([
+                exports.v4LoadTypes.LoadFailed,
+                exports.v4LoadTypes.NoMatches,
+                exports.LoadTypes.LoadFailed,
+                exports.LoadTypes.NoMatches,
+            ].includes(res.loadType)
                 ? [] // error / No matches
                 : res.loadType === exports.v4LoadTypes.PlaylistLoaded
                     ? res.data.tracks // playlist
-                    : res?.[node.options?.version === "v4" ? "data" : "tracks"] && !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"])
+                    : res?.[node.options?.version === "v4" ? "data" : "tracks"] &&
+                        !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"])
                         ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]]
                         : res?.[node.options?.version === "v4" ? "data" : "tracks"])?.filter(Boolean);
             const result = {
                 loadType: res.loadType,
-                exception: res.loadType === exports.v4LoadTypes.LoadFailed ? res.data : res.exception ?? null,
+                exception: res.loadType === exports.v4LoadTypes.LoadFailed
+                    ? res.data
+                    : res.exception ?? null,
                 pluginInfo: res.pluginInfo ?? {},
-                tracks: dataArray?.length ? dataArray?.map((track) => Utils_1.TrackUtils.build(track, requester)) : [],
+                tracks: dataArray?.length
+                    ? dataArray?.map((track) => Utils_1.TrackUtils.build(track, requester))
+                    : [],
             };
             this.applyPlaylistInfo(result, res, node);
             return resolve(result);
         });
     }
     /**
-       * Searches the a link directly without any source
-       * @param query
-       * @param requester
-       * @param customNode
-       * @returns The search result.
-       */
+     * Searches the a link directly without any source
+     * @param query
+     * @param requester
+     * @param customNode
+     * @returns The search result.
+     */
     searchLink(query, requester, customNode) {
         return new Promise(async (resolve, reject) => {
             const node = customNode || this.leastUsedNodes.first();
@@ -453,28 +531,39 @@ class Manager extends node_events_1.EventEmitter {
             const link = this.getValidUrlOfQuery(_query.query);
             if (!link)
                 return this.search(query, requester, customNode);
-            if (this.options.allowedLinksRegexes?.length || this.options.allowedLinks?.length) {
-                if (link && !this.options.allowedLinksRegexes?.some(regex => regex.test(link)) && !this.options.allowedLinks?.includes(link))
+            if (this.options.allowedLinksRegexes?.length ||
+                this.options.allowedLinks?.length) {
+                if (link &&
+                    !this.options.allowedLinksRegexes?.some((regex) => regex.test(link)) &&
+                    !this.options.allowedLinks?.includes(link))
                     reject(new Error(`Query ${_query.query} Contains link: ${link}, which is not an allowed / valid Link`));
             }
             this.validatedQuery(_query.query, node);
-            const res = await node
+            const res = (await node
                 .makeRequest(`/loadtracks?identifier=${encodeURIComponent(_query.query)}`)
-                .catch(err => reject(err));
+                .catch((err) => reject(err)));
             if (!res)
                 return reject(new Error("Query not found."));
-            const dataArray = ([exports.v4LoadTypes.LoadFailed, exports.v4LoadTypes.NoMatches, exports.LoadTypes.LoadFailed, exports.LoadTypes.NoMatches].includes(res.loadType)
+            const dataArray = ([
+                exports.v4LoadTypes.LoadFailed,
+                exports.v4LoadTypes.NoMatches,
+                exports.LoadTypes.LoadFailed,
+                exports.LoadTypes.NoMatches,
+            ].includes(res.loadType)
                 ? [] // error / No matches
                 : res.loadType === exports.v4LoadTypes.PlaylistLoaded
                     ? res.data.tracks // playlist
-                    : res?.[node.options?.version === "v4" ? "data" : "tracks"] && !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"])
+                    : res?.[node.options?.version === "v4" ? "data" : "tracks"] &&
+                        !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"])
                         ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]]
                         : res?.[node.options?.version === "v4" ? "data" : "tracks"])?.filter(Boolean);
             const result = {
                 loadType: res.loadType,
                 exception: res.exception ?? null,
                 pluginInfo: res.pluginInfo ?? {},
-                tracks: dataArray?.length ? dataArray?.map((track) => Utils_1.TrackUtils.build(track, requester)) : [],
+                tracks: dataArray?.length
+                    ? dataArray?.map((track) => Utils_1.TrackUtils.build(track, requester))
+                    : [],
             };
             this.applyPlaylistInfo(result, res, node);
             return resolve(result);
@@ -486,49 +575,66 @@ class Manager extends node_events_1.EventEmitter {
         if (!node.info.sourceManagers?.length)
             throw new Error("Lavalink Node, has no sourceManagers enabled");
         // missing links: beam.pro local getyarn.io clypit pornhub reddit ocreamix soundgasm
-        if ((Manager.regex.YoutubeMusicRegex.test(queryString) || Manager.regex.YoutubeRegex.test(queryString)) && !node.info.sourceManagers.includes("youtube")) {
+        if ((Manager.regex.YoutubeMusicRegex.test(queryString) ||
+            Manager.regex.YoutubeRegex.test(queryString)) &&
+            !node.info.sourceManagers.includes("youtube")) {
             throw new Error("Lavalink Node has not 'youtube' enabled");
         }
-        if ((Manager.regex.SoundCloudMobileRegex.test(queryString) || Manager.regex.SoundCloudRegex.test(queryString)) && !node.info.sourceManagers.includes("soundcloud")) {
+        if ((Manager.regex.SoundCloudMobileRegex.test(queryString) ||
+            Manager.regex.SoundCloudRegex.test(queryString)) &&
+            !node.info.sourceManagers.includes("soundcloud")) {
             throw new Error("Lavalink Node has not 'soundcloud' enabled");
         }
-        if (Manager.regex.bandcamp.test(queryString) && !node.info.sourceManagers.includes("bandcamp")) {
+        if (Manager.regex.bandcamp.test(queryString) &&
+            !node.info.sourceManagers.includes("bandcamp")) {
             throw new Error("Lavalink Node has not 'bandcamp' enabled");
         }
-        if (Manager.regex.TwitchTv.test(queryString) && !node.info.sourceManagers.includes("twitch")) {
+        if (Manager.regex.TwitchTv.test(queryString) &&
+            !node.info.sourceManagers.includes("twitch")) {
             throw new Error("Lavalink Node has not 'twitch' enabled");
         }
-        if (Manager.regex.vimeo.test(queryString) && !node.info.sourceManagers.includes("vimeo")) {
+        if (Manager.regex.vimeo.test(queryString) &&
+            !node.info.sourceManagers.includes("vimeo")) {
             throw new Error("Lavalink Node has not 'vimeo' enabled");
         }
-        if (Manager.regex.tiktok.test(queryString) && !node.info.sourceManagers.includes("tiktok")) {
+        if (Manager.regex.tiktok.test(queryString) &&
+            !node.info.sourceManagers.includes("tiktok")) {
             throw new Error("Lavalink Node has not 'tiktok' enabled");
         }
-        if (Manager.regex.mixcloud.test(queryString) && !node.info.sourceManagers.includes("mixcloud")) {
+        if (Manager.regex.mixcloud.test(queryString) &&
+            !node.info.sourceManagers.includes("mixcloud")) {
             throw new Error("Lavalink Node has not 'mixcloud' enabled");
         }
-        if (Manager.regex.AllSpotifyRegex.test(queryString) && !node.info.sourceManagers.includes("spotify")) {
+        if (Manager.regex.AllSpotifyRegex.test(queryString) &&
+            !node.info.sourceManagers.includes("spotify")) {
             throw new Error("Lavalink Node has not 'spotify' enabled");
         }
-        if (Manager.regex.appleMusic.test(queryString) && !node.info.sourceManagers.includes("applemusic")) {
+        if (Manager.regex.appleMusic.test(queryString) &&
+            !node.info.sourceManagers.includes("applemusic")) {
             throw new Error("Lavalink Node has not 'applemusic' enabled");
         }
-        if (Manager.regex.AllDeezerRegex.test(queryString) && !node.info.sourceManagers.includes("deezer")) {
+        if (Manager.regex.AllDeezerRegex.test(queryString) &&
+            !node.info.sourceManagers.includes("deezer")) {
             throw new Error("Lavalink Node has not 'deezer' enabled");
         }
-        if (Manager.regex.AllDeezerRegex.test(queryString) && node.info.sourceManagers.includes("deezer") && !node.info.sourceManagers.includes("http")) {
+        if (Manager.regex.AllDeezerRegex.test(queryString) &&
+            node.info.sourceManagers.includes("deezer") &&
+            !node.info.sourceManagers.includes("http")) {
             throw new Error("Lavalink Node has not 'http' enabled, which is required to have 'deezer' to work");
         }
-        if (Manager.regex.musicYandex.test(queryString) && !node.info.sourceManagers.includes("yandexmusic")) {
+        if (Manager.regex.musicYandex.test(queryString) &&
+            !node.info.sourceManagers.includes("yandexmusic")) {
             throw new Error("Lavalink Node has not 'yandexmusic' enabled");
         }
         const hasSource = queryString.split(":")[0];
-        if (queryString.split(" ").length <= 1 || !queryString.split(" ")[0].includes(":"))
+        if (queryString.split(" ").length <= 1 ||
+            !queryString.split(" ")[0].includes(":"))
             return;
         const source = Manager.DEFAULT_SOURCES[hasSource];
         if (!source)
             throw new Error(`Lavalink Node SearchQuerySource: '${hasSource}' is not available`);
-        if (source === "amsearch" && !node.info.sourceManagers.includes("applemusic")) {
+        if (source === "amsearch" &&
+            !node.info.sourceManagers.includes("applemusic")) {
             throw new Error("Lavalink Node has not 'applemusic' enabled, which is required to have 'amsearch' work");
         }
         if (source === "dzisrc" && !node.info.sourceManagers.includes("deezer")) {
@@ -537,13 +643,18 @@ class Manager extends node_events_1.EventEmitter {
         if (source === "dzsearch" && !node.info.sourceManagers.includes("deezer")) {
             throw new Error("Lavalink Node has not 'deezer' enabled, which is required to have 'dzsearch' work");
         }
-        if (source === "dzisrc" && node.info.sourceManagers.includes("deezer") && !node.info.sourceManagers.includes("http")) {
+        if (source === "dzisrc" &&
+            node.info.sourceManagers.includes("deezer") &&
+            !node.info.sourceManagers.includes("http")) {
             throw new Error("Lavalink Node has not 'http' enabled, which is required to have 'dzisrc' to work");
         }
-        if (source === "dzsearch" && node.info.sourceManagers.includes("deezer") && !node.info.sourceManagers.includes("http")) {
+        if (source === "dzsearch" &&
+            node.info.sourceManagers.includes("deezer") &&
+            !node.info.sourceManagers.includes("http")) {
             throw new Error("Lavalink Node has not 'http' enabled, which is required to have 'dzsearch' to work");
         }
-        if (source === "scsearch" && !node.info.sourceManagers.includes("soundcloud")) {
+        if (source === "scsearch" &&
+            !node.info.sourceManagers.includes("soundcloud")) {
             throw new Error("Lavalink Node has not 'soundcloud' enabled, which is required to have 'scsearch' work");
         }
         if (source === "speak" && !node.info.sourceManagers.includes("speak")) {
@@ -552,13 +663,16 @@ class Manager extends node_events_1.EventEmitter {
         if (source === "tts" && !node.info.sourceManagers.includes("tts")) {
             throw new Error("Lavalink Node has not 'tts' enabled, which is required to have 'tts' work");
         }
-        if (source === "ymsearch" && !node.info.sourceManagers.includes("yandexmusic")) {
+        if (source === "ymsearch" &&
+            !node.info.sourceManagers.includes("yandexmusic")) {
             throw new Error("Lavalink Node has not 'yandexmusic' enabled, which is required to have 'ymsearch' work");
         }
-        if (source === "ytmsearch" && !node.info.sourceManagers.includes("youtube")) {
+        if (source === "ytmsearch" &&
+            !node.info.sourceManagers.includes("youtube")) {
             throw new Error("Lavalink Node has not 'youtube' enabled, which is required to have 'ytmsearch' work");
         }
-        if (source === "ytsearch" && !node.info.sourceManagers.includes("youtube")) {
+        if (source === "ytsearch" &&
+            !node.info.sourceManagers.includes("youtube")) {
             throw new Error("Lavalink Node has not 'youtube' enabled, which is required to have 'ytsearch' work");
         }
         return;
@@ -572,13 +686,14 @@ class Manager extends node_events_1.EventEmitter {
             const node = this.nodes.first();
             if (!node)
                 throw new Error("No available nodes.");
-            const res = await node.makeRequest(`/decodetracks`, r => {
+            const res = await node
+                .makeRequest(`/decodetracks`, (r) => {
                 r.method = "POST";
                 r.body = JSON.stringify(tracks);
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 r.headers["Content-Type"] = "application/json";
             })
-                .catch(err => reject(err));
+                .catch((err) => reject(err));
             if (!res) {
                 return reject(new Error("No data returned from query."));
             }
@@ -643,10 +758,11 @@ class Manager extends node_events_1.EventEmitter {
      * @param data
      */
     async updateVoiceState(data) {
-        if ("t" in data && !["VOICE_STATE_UPDATE", "VOICE_SERVER_UPDATE"].includes(data.t))
+        if ("t" in data &&
+            !["VOICE_STATE_UPDATE", "VOICE_SERVER_UPDATE"].includes(data.t))
             return;
         const update = "d" in data ? data.d : data;
-        if (!update || !("token" in update) && !("session_id" in update))
+        if (!update || (!("token" in update) && !("session_id" in update)))
             return;
         const player = this.players.get(update.guild_id);
         if (!player)
@@ -654,7 +770,7 @@ class Manager extends node_events_1.EventEmitter {
         if ("token" in update) {
             player.voiceState.event = update;
             if (!player.node?.sessionId) {
-                if (REQUIRED_KEYS.every(key => key in player.voiceState)) {
+                if (REQUIRED_KEYS.every((key) => key in player.voiceState)) {
                     console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (manager-event#updateVoiceState)");
                     await player.node.send(player.voiceState);
                     return;
@@ -667,8 +783,8 @@ class Manager extends node_events_1.EventEmitter {
                         token: update.token,
                         endpoint: update.endpoint,
                         sessionId: player.voice?.sessionId || player.voiceState.sessionId,
-                    }
-                }
+                    },
+                },
             });
             return;
         }

--- a/dist/structures/Player.d.ts
+++ b/dist/structures/Player.d.ts
@@ -1,8 +1,7 @@
 import { LavalinkSearchPlatform, Manager, SearchQuery, SearchResult } from "./Manager";
 import { Node } from "./Node";
 import { Queue } from "./Queue";
-import { LavalinkFilterData, LavalinkPlayerVoice, TimescaleFilter } from "./Utils";
-import { State, VoiceState } from "./Utils";
+import { LavalinkFilterData, LavalinkPlayerVoice, State, TimescaleFilter, VoiceState } from "./Utils";
 export type AudioOutputs = "mono" | "stereo" | "left" | "right";
 export declare const validAudioOutputs: {
     mono: {
@@ -245,7 +244,7 @@ export declare class Player {
      * @param query
      * @param requester
      */
-    search(query: string | SearchQuery, requester?: unknown): Promise<SearchResult>;
+    search(query: string | SearchQuery, requester?: string): Promise<SearchResult>;
     /**
      * Sets the players equalizer band on-top of the existing ones.
      * @param bands

--- a/dist/structures/Player.js
+++ b/dist/structures/Player.js
@@ -4,24 +4,28 @@ exports.Player = exports.validAudioOutputs = void 0;
 const Utils_1 = require("./Utils");
 exports.validAudioOutputs = {
     mono: {
+        // totalLeft: 1, totalRight: 1
         leftToLeft: 0.5,
         leftToRight: 0.5,
         rightToLeft: 0.5,
         rightToRight: 0.5,
     },
     stereo: {
+        // totalLeft: 1, totalRight: 1
         leftToLeft: 1,
         leftToRight: 0,
         rightToLeft: 0,
         rightToRight: 1,
     },
     left: {
+        // totalLeft: 1, totalRight: 0
         leftToLeft: 0.5,
         leftToRight: 0,
         rightToLeft: 0.5,
         rightToRight: 0,
     },
     right: {
+        // totalLeft: 0, totalRight: 1
         leftToLeft: 0,
         leftToRight: 0.5,
         rightToLeft: 0,
@@ -151,15 +155,19 @@ class Player {
         /** Ping to Lavalink from Client */
         this.ping = undefined;
         /** The Voice Connection Ping from Lavalink */
-        this.wsPing = undefined,
+        (this.wsPing = undefined),
             /** The equalizer bands array. */
-            this.bands = new Array(15).fill(0.0);
+            (this.bands = new Array(15).fill(0.0));
         this.set("lastposition", undefined);
-        if (typeof options.customData === "object" && Object.keys(options.customData).length) {
+        if (typeof options.customData === "object" &&
+            Object.keys(options.customData).length) {
             this.data = { ...this.data, ...options.customData };
         }
         this.guild = options.guild;
-        this.voiceState = Object.assign({ op: "voiceUpdate", guildId: options.guild });
+        this.voiceState = Object.assign({
+            op: "voiceUpdate",
+            guildId: options.guild,
+        });
         if (options.voiceChannel)
             this.voiceChannel = options.voiceChannel;
         if (options.textChannel)
@@ -173,7 +181,9 @@ class Player {
         }
         this.region = options?.region;
         const customNode = this.manager.nodes.get(options.node);
-        const regionNode = this.manager.leastUsedNodes.filter(x => x.regions?.includes(options.region?.toLowerCase()))?.first();
+        const regionNode = this.manager.leastUsedNodes
+            .filter((x) => x.regions?.includes(options.region?.toLowerCase()))
+            ?.first();
         this.node = customNode || regionNode || this.manager.leastUsedNodes.first();
         if (!this.node)
             throw new RangeError("No available nodes.");
@@ -194,37 +204,37 @@ class Player {
         };
         this.filterData = {
             lowPass: {
-                smoothing: 0
+                smoothing: 0,
             },
             karaoke: {
                 level: 0,
                 monoLevel: 0,
                 filterBand: 0,
-                filterWidth: 0
+                filterWidth: 0,
             },
             timescale: {
                 speed: 1,
                 pitch: 1,
-                rate: 1 // 0 = x
+                rate: 1, // 0 = x
             },
             echo: {
                 delay: 0,
-                decay: 0
+                decay: 0,
             },
             reverb: {
                 delay: 0,
-                decay: 0
+                decay: 0,
             },
             rotation: {
-                rotationHz: 0
+                rotationHz: 0,
             },
             tremolo: {
                 frequency: 2,
-                depth: 0.1 // 0 < x = 1
+                depth: 0.1, // 0 < x = 1
             },
             vibrato: {
                 frequency: 2,
-                depth: 0.1 // 0 < x = 1
+                depth: 0.1, // 0 < x = 1
             },
             channelMix: exports.validAudioOutputs.stereo,
             /*distortion: {
@@ -244,15 +254,24 @@ class Player {
     }
     checkFiltersState(oldFilterTimescale) {
         this.filters.rotation = this.filterData.rotation.rotationHz !== 0;
-        this.filters.vibrato = this.filterData.vibrato.frequency !== 0 || this.filterData.vibrato.depth !== 0;
-        this.filters.tremolo = this.filterData.tremolo.frequency !== 0 || this.filterData.tremolo.depth !== 0;
-        this.filters.echo = this.filterData.echo.decay !== 0 || this.filterData.echo.delay !== 0;
-        this.filters.reverb = this.filterData.reverb.decay !== 0 || this.filterData.reverb.delay !== 0;
+        this.filters.vibrato =
+            this.filterData.vibrato.frequency !== 0 ||
+                this.filterData.vibrato.depth !== 0;
+        this.filters.tremolo =
+            this.filterData.tremolo.frequency !== 0 ||
+                this.filterData.tremolo.depth !== 0;
+        this.filters.echo =
+            this.filterData.echo.decay !== 0 || this.filterData.echo.delay !== 0;
+        this.filters.reverb =
+            this.filterData.reverb.decay !== 0 || this.filterData.reverb.delay !== 0;
         this.filters.lowPass = this.filterData.lowPass.smoothing !== 0;
-        this.filters.karaoke = Object.values(this.filterData.karaoke).some(v => v !== 0);
-        if ((this.filters.nightcore || this.filters.vaporwave) && oldFilterTimescale) {
-            if (oldFilterTimescale.pitch !== this.filterData.timescale.pitch || oldFilterTimescale.rate !== this.filterData.timescale.rate || oldFilterTimescale.speed !== this.filterData.timescale.speed) {
-                this.filters.custom = Object.values(this.filterData.timescale).some(v => v !== 1);
+        this.filters.karaoke = Object.values(this.filterData.karaoke).some((v) => v !== 0);
+        if ((this.filters.nightcore || this.filters.vaporwave) &&
+            oldFilterTimescale) {
+            if (oldFilterTimescale.pitch !== this.filterData.timescale.pitch ||
+                oldFilterTimescale.rate !== this.filterData.timescale.rate ||
+                oldFilterTimescale.speed !== this.filterData.timescale.speed) {
+                this.filters.custom = Object.values(this.filterData.timescale).some((v) => v !== 1);
                 this.filters.nightcore = false;
                 this.filters.vaporwave = false;
             }
@@ -279,37 +298,37 @@ class Player {
         for (const [key, value] of Object.entries({
             volume: 1,
             lowPass: {
-                smoothing: 0
+                smoothing: 0,
             },
             karaoke: {
                 level: 0,
                 monoLevel: 0,
                 filterBand: 0,
-                filterWidth: 0
+                filterWidth: 0,
             },
             timescale: {
                 speed: 1,
                 pitch: 1,
-                rate: 1 // 0 = x
+                rate: 1, // 0 = x
             },
             echo: {
                 delay: 0,
-                decay: 0
+                decay: 0,
             },
             reverb: {
                 delay: 0,
-                decay: 0
+                decay: 0,
             },
             rotation: {
-                rotationHz: 0
+                rotationHz: 0,
             },
             tremolo: {
                 frequency: 2,
-                depth: 0.1 // 0 < x = 1
+                depth: 0.1, // 0 < x = 1
             },
             vibrato: {
                 frequency: 2,
-                depth: 0.1 // 0 < x = 1
+                depth: 0.1, // 0 < x = 1
             },
             channelMix: exports.validAudioOutputs.stereo,
         })) {
@@ -406,7 +425,9 @@ class Player {
     async toggleRotation(rotationHz = 0.2) {
         if (this.node.info && !this.node.info?.filters?.includes("rotation"))
             throw new Error("Node#Info#filters does not include the 'rotation' Filter (Node has it not enable)");
-        this.filterData.rotation.rotationHz = this.filters.rotation ? 0 : rotationHz;
+        this.filterData.rotation.rotationHz = this.filters.rotation
+            ? 0
+            : rotationHz;
         this.filters.rotation = !this.filters.rotation;
         /** @deprecated but sync with rotating */
         this.filters.rotating = this.filters.rotation;
@@ -420,7 +441,9 @@ class Player {
     async toggleRotating(rotationHz = 0.2) {
         if (this.node.info && !this.node.info?.filters?.includes("rotation"))
             throw new Error("Node#Info#filters does not include the 'rotation' Filter (Node has it not enable)");
-        this.filterData.rotation.rotationHz = this.filters.rotation ? 0 : rotationHz;
+        this.filterData.rotation.rotationHz = this.filters.rotation
+            ? 0
+            : rotationHz;
         this.filters.rotation = !this.filters.rotation;
         /** @deprecated but sync with rotating */
         this.filters.rotating = this.filters.rotation;
@@ -551,14 +574,19 @@ class Player {
         this.filterData.karaoke.level = this.filters.karaoke ? 0 : level;
         this.filterData.karaoke.monoLevel = this.filters.karaoke ? 0 : monoLevel;
         this.filterData.karaoke.filterBand = this.filters.karaoke ? 0 : filterBand;
-        this.filterData.karaoke.filterWidth = this.filters.karaoke ? 0 : filterWidth;
+        this.filterData.karaoke.filterWidth = this.filters.karaoke
+            ? 0
+            : filterWidth;
         this.filters.karaoke = !this.filters.karaoke;
         await this.updatePlayerFilters();
         return this.filters.karaoke;
     }
     /** Function to find out if currently there is a custom timescamle etc. filter applied */
     isCustomFilterActive() {
-        this.filters.custom = !this.filters.nightcore && !this.filters.vaporwave && Object.values(this.filterData.timescale).some(d => d !== 1);
+        this.filters.custom =
+            !this.filters.nightcore &&
+                !this.filters.vaporwave &&
+                Object.values(this.filterData.timescale).some((d) => d !== 1);
         return this.filters.custom;
     }
     // function to update all filters at ONCE (and eqs)
@@ -594,7 +622,7 @@ class Player {
                 op: "filters",
                 guildId: this.guild,
                 equalizer: this.bands.map((gain, band) => ({ band, gain })),
-                ...sendData
+                ...sendData,
             });
         }
         else {
@@ -607,7 +635,7 @@ class Player {
                 guildId: this.guild,
                 playerOptions: {
                     filters: sendData,
-                }
+                },
             });
         }
         this.ping = Date.now() - now;
@@ -631,7 +659,8 @@ class Player {
         // Hacky support for providing an array
         if (Array.isArray(bands[0]))
             bands = bands[0];
-        if (!bands.length || !bands.every((band) => JSON.stringify(Object.keys(band).sort()) === '["band","gain"]'))
+        if (!bands.length ||
+            !bands.every((band) => JSON.stringify(Object.keys(band).sort()) === '["band","gain"]'))
             throw new TypeError("Bands must be a non-empty object array containing 'band' and 'gain' properties.");
         for (const { band, gain } of bands)
             this.bands[band] = gain;
@@ -647,8 +676,10 @@ class Player {
             await this.node.updatePlayer({
                 guildId: this.guild,
                 playerOptions: {
-                    filters: { equalizer: this.bands.map((gain, band) => ({ band, gain })) }
-                }
+                    filters: {
+                        equalizer: this.bands.map((gain, band) => ({ band, gain })),
+                    },
+                },
             });
         }
         return this;
@@ -668,8 +699,10 @@ class Player {
             await this.node.updatePlayer({
                 guildId: this.guild,
                 playerOptions: {
-                    filters: { equalizer: this.bands.map((gain, band) => ({ band, gain })) }
-                }
+                    filters: {
+                        equalizer: this.bands.map((gain, band) => ({ band, gain })),
+                    },
+                },
             });
         }
         return this;
@@ -750,7 +783,9 @@ class Player {
         }
         if (!this.queue.current)
             throw new RangeError("No current track.");
-        const finalOptions = getOptions(playOptions || optionsOrTrack, !!this.node.sessionId) ? optionsOrTrack : {};
+        const finalOptions = getOptions(playOptions || optionsOrTrack, !!this.node.sessionId)
+            ? optionsOrTrack
+            : {};
         if (Utils_1.TrackUtils.isUnresolvedTrack(this.queue.current)) {
             try {
                 this.queue.current = await Utils_1.TrackUtils.getClosestTrack(this.queue.current, this.node);
@@ -786,7 +821,7 @@ class Player {
                 track: options.encodedTrack,
                 op: "play",
                 guildId: this.guild,
-                ...finalOptions
+                ...finalOptions,
             });
         }
         else {
@@ -826,16 +861,16 @@ class Player {
                 await this.node.updatePlayer({
                     guildId: this.guild,
                     playerOptions: {
-                        filters: { volume: vol / 100 }
-                    }
+                        filters: { volume: vol / 100 },
+                    },
                 });
             }
             else {
                 await this.node.updatePlayer({
                     guildId: this.guild,
                     playerOptions: {
-                        volume: vol
-                    }
+                        volume: vol,
+                    },
                 });
             }
         }
@@ -858,8 +893,8 @@ class Player {
         await this.node.updatePlayer({
             guildId: this.guild,
             playerOptions: {
-                filters: { volume: this.filterData.volume }
-            }
+                filters: { volume: this.filterData.volume },
+            },
         });
         this.ping = Date.now() - now;
         return this;
@@ -916,7 +951,7 @@ class Player {
         else {
             await this.node.updatePlayer({
                 guildId: this.guild,
-                playerOptions: { encodedTrack: null }
+                playerOptions: { encodedTrack: null },
             });
         }
         this.ping = Date.now() - now;
@@ -979,7 +1014,7 @@ class Player {
         else {
             await this.node.updatePlayer({
                 guildId: this.guild,
-                playerOptions: { position }
+                playerOptions: { position },
             });
         }
         this.ping = Date.now() - now;
@@ -988,12 +1023,20 @@ class Player {
 }
 exports.Player = Player;
 function getOptions(opts, allowFilters) {
-    const valids = ["startTime", "endTime", "noReplace", "volume", "pause", "filters"];
+    const valids = [
+        "startTime",
+        "endTime",
+        "noReplace",
+        "volume",
+        "pause",
+        "filters",
+    ];
     const returnObject = {};
     if (!opts)
         return false;
     for (const [key, value] of Object.entries(Object.assign({}, opts))) {
-        if (valids.includes(key) && (key !== "filters" || (key === "filters" && allowFilters))) {
+        if (valids.includes(key) &&
+            (key !== "filters" || (key === "filters" && allowFilters))) {
             returnObject[key] = value;
         }
     }

--- a/dist/structures/Utils.d.ts
+++ b/dist/structures/Utils.d.ts
@@ -93,8 +93,7 @@ export interface LavalinkPlayerVoice {
     connected?: boolean;
     ping?: number;
 }
-export interface LavalinkPlayerVoiceOptions extends Omit<LavalinkPlayerVoice, 'connected' | 'ping'> {
-}
+export type LavalinkPlayerVoiceOptions = Omit<LavalinkPlayerVoice, 'connected' | 'ping'>;
 export interface PlayerUpdateOptions {
     encodedTrack?: string | null;
     identifier?: string;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "discord.js",
     "eris"
   ],
-  "author": "FOrker: Tomato6966 | Original: MenuDocs (https://github.com/MenuDocs)",
+  "author": "Forker: Tomato6966 | Original: MenuDocs (https://github.com/MenuDocs)",
   "contributors": [
     "Solaris9",
     "Anish-Shobith",

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -4,10 +4,10 @@ import { EventEmitter } from "node:events";
 import { VoiceState } from "..";
 import { Node, NodeOptions } from "./Node";
 import { Player, PlayerOptions, Track, UnresolvedTrack } from "./Player";
-import { PluginDataInfo, v4LoadType } from "./Utils";
 import {
   LoadType,
   Plugin,
+  PluginDataInfo,
   Structure,
   TrackData,
   TrackEndEvent,
@@ -18,6 +18,7 @@ import {
   VoicePacket,
   VoiceServer,
   WebSocketClosedEvent,
+  v4LoadType,
 } from "./Utils";
 
 const REQUIRED_KEYS = ["event", "guildId", "op", "sessionId"];
@@ -28,302 +29,425 @@ export const v4LoadTypes = {
   SearchResult: "search",
   NoMatches: "empty",
   LoadFailed: "error",
-}
+};
 export const LoadTypes = {
   TrackLoaded: "TRACK_LOADED",
   PlaylistLoaded: "PLAYLIST_LOADED",
   SearchResult: "SEARCH_RESULT",
   NoMatches: "NO_MATCHES",
-  LoadFailed: "LOAD_FAILED"
-} as Record<"TrackLoaded"|"PlaylistLoaded"|"SearchResult"|"NoMatches"|"LoadFailed", LoadType>
-
-
+  LoadFailed: "LOAD_FAILED",
+} as Record<
+  | "TrackLoaded"
+  | "PlaylistLoaded"
+  | "SearchResult"
+  | "NoMatches"
+  | "LoadFailed",
+  LoadType
+>;
 
 function check(options: ManagerOptions) {
   if (!options) throw new TypeError("ManagerOptions must not be empty.");
 
-  if (typeof options.send !== "function") 
-    throw new TypeError('Manager option "send" must be present and a function.');
+  if (typeof options.send !== "function")
+    throw new TypeError(
+      'Manager option "send" must be present and a function.'
+    );
 
-  if (typeof options.clientId !== "undefined" && !/^\d+$/.test(options.clientId))
-    throw new TypeError('Manager option "clientId" must be a non-empty string.');
+  if (
+    typeof options.clientId !== "undefined" &&
+    !/^\d+$/.test(options.clientId)
+  )
+    throw new TypeError(
+      'Manager option "clientId" must be a non-empty string.'
+    );
 
   if (typeof options.nodes !== "undefined" && !Array.isArray(options.nodes))
     throw new TypeError('Manager option "nodes" must be a array.');
 
-  if (typeof options.shards !== "undefined" && typeof options.shards !== "number")
+  if (
+    typeof options.shards !== "undefined" &&
+    typeof options.shards !== "number"
+  )
     throw new TypeError('Manager option "shards" must be a number.');
 
   if (typeof options.plugins !== "undefined" && !Array.isArray(options.plugins))
     throw new TypeError('Manager option "plugins" must be a Plugin array.');
 
-  if (typeof options.autoPlay !== "undefined" &&typeof options.autoPlay !== "boolean")
+  if (
+    typeof options.autoPlay !== "undefined" &&
+    typeof options.autoPlay !== "boolean"
+  )
     throw new TypeError('Manager option "autoPlay" must be a boolean.');
 
-  if (typeof options.trackPartial !== "undefined" && !Array.isArray(options.trackPartial))
-    throw new TypeError('Manager option "trackPartial" must be a string array.');
+  if (
+    typeof options.trackPartial !== "undefined" &&
+    !Array.isArray(options.trackPartial)
+  )
+    throw new TypeError(
+      'Manager option "trackPartial" must be a string array.'
+    );
 
-  if (typeof options.clientName !== "undefined" && typeof options.clientName !== "string")
+  if (
+    typeof options.clientName !== "undefined" &&
+    typeof options.clientName !== "string"
+  )
     throw new TypeError('Manager option "clientName" must be a string.');
-  
-  if (typeof options.defaultSearchPlatform !== "undefined" && typeof options.defaultSearchPlatform !== "string")
-  throw new TypeError('Manager option "defaultSearchPlatform" must be a string.');
 
-  if (typeof options.volumeDecrementer !== "undefined" && (typeof options.volumeDecrementer !== "number" || isNaN(options.volumeDecrementer)))
-    throw new TypeError('Manager option "volumeDecrementer" must be a number between 0 and 1.');
+  if (
+    typeof options.defaultSearchPlatform !== "undefined" &&
+    typeof options.defaultSearchPlatform !== "string"
+  )
+    throw new TypeError(
+      'Manager option "defaultSearchPlatform" must be a string.'
+    );
+
+  if (
+    typeof options.volumeDecrementer !== "undefined" &&
+    (typeof options.volumeDecrementer !== "number" ||
+      isNaN(options.volumeDecrementer))
+  )
+    throw new TypeError(
+      'Manager option "volumeDecrementer" must be a number between 0 and 1.'
+    );
 
   if (options.volumeDecrementer > 1 || options.volumeDecrementer < 0)
-    throw new TypeError('Manager option "volumeDecrementer" must be a number between 0 and 1.');
+    throw new TypeError(
+      'Manager option "volumeDecrementer" must be a number between 0 and 1.'
+    );
 
-  if (typeof options.position_update_interval !== "undefined" && (typeof options.position_update_interval !== "number" || isNaN(options.position_update_interval)))
-    throw new TypeError('Manager option "position_update_interval" must be a number between 50 and 1000., set it to 0 to disable it');
-    
-  if ((options.position_update_interval > 1000 || options.position_update_interval < 50) && options.position_update_interval !== 0)
-  throw new TypeError('Manager option "position_update_interval" must be a number between 50 and 1000., set it to 0 to disable it');
+  if (
+    typeof options.position_update_interval !== "undefined" &&
+    (typeof options.position_update_interval !== "number" ||
+      isNaN(options.position_update_interval))
+  )
+    throw new TypeError(
+      'Manager option "position_update_interval" must be a number between 50 and 1000., set it to 0 to disable it'
+    );
 
-  if (typeof options.validUnresolvedUris !== "undefined" && !Array.isArray(options.validUnresolvedUris) && !(options.validUnresolvedUris as string[]).every(v => typeof v === "string"))
-    throw new TypeError('Manager option "validUnresolvedUris" must be an array of strings');
-  
-  if (typeof options.forceLoadPlugin !== "undefined" && typeof options.forceLoadPlugin !== "boolean")
+  if (
+    (options.position_update_interval > 1000 ||
+      options.position_update_interval < 50) &&
+    options.position_update_interval !== 0
+  )
+    throw new TypeError(
+      'Manager option "position_update_interval" must be a number between 50 and 1000., set it to 0 to disable it'
+    );
+
+  if (
+    typeof options.validUnresolvedUris !== "undefined" &&
+    !Array.isArray(options.validUnresolvedUris) &&
+    !(options.validUnresolvedUris as string[]).every(
+      (v) => typeof v === "string"
+    )
+  )
+    throw new TypeError(
+      'Manager option "validUnresolvedUris" must be an array of strings'
+    );
+
+  if (
+    typeof options.forceLoadPlugin !== "undefined" &&
+    typeof options.forceLoadPlugin !== "boolean"
+  )
     throw new TypeError('Manager option "forceLoadPlugin" must be a boolean');
-  
-  if (typeof options.allowedLinks !== "undefined" && !Array.isArray(options.allowedLinks) && !(options.allowedLinks as string[]).every(v => typeof v === "string"))
-    throw new TypeError('Manager option "allowedLinks" must be an array of strings');
- 
-  if (typeof options.allowedLinksRegexes !== "undefined" && !Array.isArray(options.allowedLinksRegexes) && !(options.allowedLinksRegexes as RegExp[]).every(v => v instanceof RegExp))
-    throw new TypeError('Manager option "allowedLinksRegexes" must be an array of regexes');
-  
-  if (typeof options.onlyAllowAllowedLinks !== "undefined" && typeof options.onlyAllowAllowedLinks !== "boolean")
-    throw new TypeError('Manager option "onlyAllowAllowedLinks" must be a boolean');
-  
-  if (typeof options.defaultLeastUsedNodeSortType !== "undefined" && options.defaultLeastUsedNodeSortType !== "memory" && options.defaultLeastUsedNodeSortType !== "calls" && options.defaultLeastUsedNodeSortType !== "players")
-    throw new TypeError('Manager option "defaultLeastUsedNodeSortType" must be a string of leastUsedNodeSortType ("memory" | "calls" | "players")');
-  
-  if (typeof options.defaultLeastLoadNodeSortType !== "undefined" && options.defaultLeastLoadNodeSortType !== "cpu" && options.defaultLeastLoadNodeSortType !== "memory")
-    throw new TypeError('Manager option "defaultLeastLoadNodeSortType" must be a string of leastUsedNodeSortType ("cpu" | "memory")');
-  
-  if (typeof options.useUnresolvedData !== "undefined" && typeof options.useUnresolvedData !== "boolean")
+
+  if (
+    typeof options.allowedLinks !== "undefined" &&
+    !Array.isArray(options.allowedLinks) &&
+    !(options.allowedLinks as string[]).every((v) => typeof v === "string")
+  )
+    throw new TypeError(
+      'Manager option "allowedLinks" must be an array of strings'
+    );
+
+  if (
+    typeof options.allowedLinksRegexes !== "undefined" &&
+    !Array.isArray(options.allowedLinksRegexes) &&
+    !(options.allowedLinksRegexes as RegExp[]).every((v) => v instanceof RegExp)
+  )
+    throw new TypeError(
+      'Manager option "allowedLinksRegexes" must be an array of regexes'
+    );
+
+  if (
+    typeof options.onlyAllowAllowedLinks !== "undefined" &&
+    typeof options.onlyAllowAllowedLinks !== "boolean"
+  )
+    throw new TypeError(
+      'Manager option "onlyAllowAllowedLinks" must be a boolean'
+    );
+
+  if (
+    typeof options.defaultLeastUsedNodeSortType !== "undefined" &&
+    options.defaultLeastUsedNodeSortType !== "memory" &&
+    options.defaultLeastUsedNodeSortType !== "calls" &&
+    options.defaultLeastUsedNodeSortType !== "players"
+  )
+    throw new TypeError(
+      'Manager option "defaultLeastUsedNodeSortType" must be a string of leastUsedNodeSortType ("memory" | "calls" | "players")'
+    );
+
+  if (
+    typeof options.defaultLeastLoadNodeSortType !== "undefined" &&
+    options.defaultLeastLoadNodeSortType !== "cpu" &&
+    options.defaultLeastLoadNodeSortType !== "memory"
+  )
+    throw new TypeError(
+      'Manager option "defaultLeastLoadNodeSortType" must be a string of leastUsedNodeSortType ("cpu" | "memory")'
+    );
+
+  if (
+    typeof options.useUnresolvedData !== "undefined" &&
+    typeof options.useUnresolvedData !== "boolean"
+  )
     throw new TypeError('Manager option "useUnresolvedData" must be a boolean');
-  
-  if (typeof options.forceSearchLinkQueries !== "undefined" && typeof options.forceSearchLinkQueries !== "boolean")
-    throw new TypeError('Manager option "forceSearchLinkQueries" must be a boolean');
-  
-  if (typeof options.userAgent !== "undefined" && typeof options.userAgent !== "string")
-    throw new TypeError('Manager option "userAgent" must be a string (public useragent when doing fetch requests)');
-  
-  if (typeof options.restTimeout !== "undefined" && (typeof options.restTimeout !== "number" || isNaN(options.restTimeout)))
+
+  if (
+    typeof options.forceSearchLinkQueries !== "undefined" &&
+    typeof options.forceSearchLinkQueries !== "boolean"
+  )
+    throw new TypeError(
+      'Manager option "forceSearchLinkQueries" must be a boolean'
+    );
+
+  if (
+    typeof options.userAgent !== "undefined" &&
+    typeof options.userAgent !== "string"
+  )
+    throw new TypeError(
+      'Manager option "userAgent" must be a string (public useragent when doing fetch requests)'
+    );
+
+  if (
+    typeof options.restTimeout !== "undefined" &&
+    (typeof options.restTimeout !== "number" || isNaN(options.restTimeout))
+  )
     throw new TypeError('Manager option "restTimeout" must be a number');
-    
-  if (typeof options.applyVolumeAsFilter !== "undefined" && typeof options.applyVolumeAsFilter !== "boolean")
-    throw new TypeError('Manager option "applyVolumeAsFilter" must be a boolean');
+
+  if (
+    typeof options.applyVolumeAsFilter !== "undefined" &&
+    typeof options.applyVolumeAsFilter !== "boolean"
+  )
+    throw new TypeError(
+      'Manager option "applyVolumeAsFilter" must be a boolean'
+    );
 }
 
-export interface Manager {
+export interface ManagerEvents {
   /**
    * Emitted when a Node is created.
    * @event Manager#nodeCreate
    */
-  on(event: "nodeCreate", listener: (node: Node) => void): this;
+  nodeCreate: (node: Node) => void;
 
   /**
    * Emitted when a Node is destroyed.
    * @event Manager#nodeDestroy
    */
-  on(event: "nodeDestroy", listener: (node: Node) => void): this;
-
+  nodeDestroy: (node: Node) => void;
   /**
    * Emitted when a Node connects.
    * @event Manager#nodeConnect
    */
-  on(event: "nodeConnect", listener: (node: Node) => void): this;
+  nodeConnect: (node: Node) => void;
 
   /**
    * Emitted when a Node reconnects.
    * @event Manager#nodeReconnect
    */
-  on(event: "nodeReconnect", listener: (node: Node) => void): this;
+  nodeReconnect: (node: Node) => void;
 
   /**
    * Emitted when a Node disconnects.
    * @event Manager#nodeDisconnect
    */
-  on(
-    event: "nodeDisconnect",
-    listener: (node: Node, reason: { code?: number; reason?: string }) => void
-  ): this;
+  nodeDisconnect: (
+    node: Node,
+    reason: { code?: number; reason?: string }
+  ) => void;
 
   /**
    * Emitted when a Node has an error.
    * @event Manager#nodeError
    */
-  on(event: "nodeError", listener: (node: Node, error: Error) => void): this;
+  nodeError: (node: Node, error: Error) => void;
 
   /**
    * Emitted whenever any Lavalink event is received.
    * @event Manager#nodeRaw
    */
-  on(event: "nodeRaw", listener: (payload: unknown) => void): this;
+  nodeRaw: (payload: unknown) => void;
 
   /**
    * Emitted when a player is created.
    * @event Manager#playerCreate
    */
-  on(event: "playerCreate", listener: (player: Player) => void): this;
+  playerCreate: (player: Player) => void;
 
   /**
    * Emitted when a player is destroyed.
    * @event Manager#playerDestroy
    */
-  on(event: "playerDestroy", listener: (player: Player) => void): this;
+  playerDestroy: (player: Player) => void;
 
   /**
    * Emitted when a player queue ends.
    * @event Manager#queueEnd
    */
-  on(
-    event: "queueEnd",
-    listener: (
-      player: Player,
-      track: Track | UnresolvedTrack,
-      payload: TrackEndEvent
-    ) => void
-  ): this;
+  queueEnd: (
+    player: Player,
+    track: Track | UnresolvedTrack,
+    payload: TrackEndEvent
+  ) => void;
 
   /**
    * Emitted when a player is moved to a new voice channel.
    * @event Manager#playerMove
    */
-  on(
-    event: "playerMove",
-    listener: (player: Player, initChannel: string, newChannel: string) => void
-  ): this;
+  playerMove: (player: Player, initChannel: string, newChannel: string) => void;
 
   /**
    * Emitted when a player is disconnected from it's current voice channel.
    * @event Manager#playerDisconnect
    */
-  on(
-    event: "playerDisconnect",
-    listener: (player: Player, oldChannel: string) => void
-  ): this;
+  playerDisconnect: (player: Player, oldChannel: string) => void;
 
   /**
    * Emitted when a track starts.
    * @event Manager#trackStart
    */
-  on(
-    event: "trackStart",
-    listener: (player: Player, track: Track, payload: TrackStartEvent) => void
-  ): this;
+  trackStart: (player: Player, track: Track, payload: TrackStartEvent) => void;
 
   /**
    * Emitted when a track ends.
    * @event Manager#trackEnd
    */
-  on(
-    event: "trackEnd",
-    listener: (player: Player, track: Track, payload: TrackEndEvent) => void
-  ): this;
+  trackEnd: (player: Player, track: Track, payload: TrackEndEvent) => void;
 
   /**
    * Emitted when a track gets stuck during playback.
    * @event Manager#trackStuck
    */
-  on(
-    event: "trackStuck",
-    listener: (player: Player, track: Track, payload: TrackStuckEvent) => void
-  ): this;
+  trackStuck: (player: Player, track: Track, payload: TrackStuckEvent) => void;
 
   /**
    * Emitted when a track has an error during playback.
    * @event Manager#trackError
    */
-  on(
-    event: "trackError",
-    listener: (
-      player: Player,
-      track: Track | UnresolvedTrack,
-      payload: TrackExceptionEvent
-    ) => void
-  ): this;
+  trackError: (
+    player: Player,
+    track: Track | UnresolvedTrack,
+    payload: TrackExceptionEvent
+  ) => void;
 
   /**
    * Emitted when a voice connection is closed.
    * @event Manager#socketClosed
    */
-  on(
-    event: "socketClosed",
-    listener: (player: Player, payload: WebSocketClosedEvent) => void
-  ): this;
+  socketClosed: (player: Player, payload: WebSocketClosedEvent) => void;
 }
 
+export interface Manager {
+  on<K extends keyof ManagerEvents>(event: K, listener: ManagerEvents[K]): this;
+  once<K extends keyof ManagerEvents>(
+    event: K,
+    listener: ManagerEvents[K]
+  ): this;
+  emit<K extends keyof ManagerEvents>(
+    event: K,
+    ...args: Parameters<ManagerEvents[K]>
+  ): boolean;
+  off<K extends keyof ManagerEvents>(
+    event: K,
+    listener: ManagerEvents[K]
+  ): this;
+}
 
 /**
  * The main hub for interacting with Lavalink and using Erela.JS,
  * @noInheritDoc
  */
 export class Manager extends EventEmitter {
-  public static readonly DEFAULT_SOURCES: Record<SearchPlatform, LavalinkSearchPlatform> = {
+  public static readonly DEFAULT_SOURCES: Record<
+    SearchPlatform,
+    LavalinkSearchPlatform
+  > = {
     // youtubemusic
     "youtube music": "ytmsearch",
-    "ytmsearch": "ytmsearch",
-    "ytm": "ytmsearch",
+    ytmsearch: "ytmsearch",
+    ytm: "ytmsearch",
     // youtube
-    "youtube": "ytsearch",
-    "yt": "ytsearch",
-    "ytsearch": "ytsearch",
+    youtube: "ytsearch",
+    yt: "ytsearch",
+    ytsearch: "ytsearch",
     // soundcloud
-    "soundcloud": "scsearch",
-    "scsearch": "scsearch",
-    "sc": "scsearch",
+    soundcloud: "scsearch",
+    scsearch: "scsearch",
+    sc: "scsearch",
     // apple music
-    "amsearch": "amsearch",
-    "am": "amsearch",
-    // spotify 
-    "spsearch": "spsearch",
-    "sp": "spsearch",
-    "sprec": "sprec",
-    "spsuggestion": "sprec",
+    amsearch: "amsearch",
+    am: "amsearch",
+    // spotify
+    spsearch: "spsearch",
+    sp: "spsearch",
+    sprec: "sprec",
+    spsuggestion: "sprec",
     // deezer
-    "dz": "dzsearch",
-    "deezer": "dzsearch",
-    "ds": "dzsearch",
-    "dzsearch": "dzsearch",
-    "dzisrc": "dzisrc",
+    dz: "dzsearch",
+    deezer: "dzsearch",
+    ds: "dzsearch",
+    dzsearch: "dzsearch",
+    dzisrc: "dzisrc",
     // yandexmusic
-    "yandexmusic": "ymsearch",
-    "yandex": "ymsearch",
-    "ymsearch": "ymsearch",
+    yandexmusic: "ymsearch",
+    yandex: "ymsearch",
+    ymsearch: "ymsearch",
     // speak
-    "speak": "speak",
-    "tts": "tts",
-  }
+    speak: "speak",
+    tts: "tts",
+  };
   public static readonly regex: Record<SourcesRegex, RegExp> = {
-    YoutubeRegex: /https?:\/\/?(?:www\.)?(?:(m|www)\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|shorts|playlist\?|watch\?v=|watch\?.+(?:&|&#38;);v=))([a-zA-Z0-9\-_]{11})?(?:(?:\?|&|&#38;)index=((?:\d){1,3}))?(?:(?:\?|&|&#38;)?list=([a-zA-Z\-_0-9]{34}))?(?:\S+)?/,
-    YoutubeMusicRegex: /https?:\/\/?(?:www\.)?(?:(music|m|www)\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|shorts|playlist\?|watch\?v=|watch\?.+(?:&|&#38;);v=))([a-zA-Z0-9\-_]{11})?(?:(?:\?|&|&#38;)index=((?:\d){1,3}))?(?:(?:\?|&|&#38;)?list=([a-zA-Z\-_0-9]{34}))?(?:\S+)?/,
-    
+    YoutubeRegex:
+      /https?:\/\/?(?:www\.)?(?:(m|www)\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|shorts|playlist\?|watch\?v=|watch\?.+(?:&|&#38;);v=))([a-zA-Z0-9\-_]{11})?(?:(?:\?|&|&#38;)index=((?:\d){1,3}))?(?:(?:\?|&|&#38;)?list=([a-zA-Z\-_0-9]{34}))?(?:\S+)?/,
+    YoutubeMusicRegex:
+      /https?:\/\/?(?:www\.)?(?:(music|m|www)\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|shorts|playlist\?|watch\?v=|watch\?.+(?:&|&#38;);v=))([a-zA-Z0-9\-_]{11})?(?:(?:\?|&|&#38;)index=((?:\d){1,3}))?(?:(?:\?|&|&#38;)?list=([a-zA-Z\-_0-9]{34}))?(?:\S+)?/,
+
     SoundCloudRegex: /https:\/\/(?:on\.)?soundcloud\.com\//,
     SoundCloudMobileRegex: /https?:\/\/(soundcloud\.app\.goo\.gl)\/(\S+)/,
 
-    DeezerTrackRegex: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?track\/(\d+)/,
+    DeezerTrackRegex:
+      /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?track\/(\d+)/,
     DeezerPageLinkRegex: /(https?:\/\/|)?(?:www\.)?deezer\.page\.link\/(\S+)/,
-    DeezerPlaylistRegex: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?playlist\/(\d+)/,
-    DeezerAlbumRegex: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?album\/(\d+)/,
-    DeezerArtistRegex: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?artist\/(\d+)/,
-    DeezerMixesRegex: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?mixes\/genre\/(\d+)/,
-    DeezerEpisodeRegex: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?episode\/(\d+)/,
+    DeezerPlaylistRegex:
+      /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?playlist\/(\d+)/,
+    DeezerAlbumRegex:
+      /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?album\/(\d+)/,
+    DeezerArtistRegex:
+      /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?artist\/(\d+)/,
+    DeezerMixesRegex:
+      /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?mixes\/genre\/(\d+)/,
+    DeezerEpisodeRegex:
+      /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?episode\/(\d+)/,
     // DeezerPodcastRegex: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?podcast\/(\d+)/,
-    AllDeezerRegexWithoutPageLink: /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?(track|playlist|album|artist|mixes\/genre|episode)\/(\d+)/,
-    AllDeezerRegex: /((https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?(track|playlist|album|artist|mixes\/genre|episode)\/(\d+)|(https?:\/\/|)?(?:www\.)?deezer\.page\.link\/(\S+))/,
-    
-    SpotifySongRegex: /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?track\/(?<identifier>[a-zA-Z0-9-_]+)/,
-    SpotifyPlaylistRegex: /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?playlist\/(?<identifier>[a-zA-Z0-9-_]+)/,
-    SpotifyArtistRegex: /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?artist\/(?<identifier>[a-zA-Z0-9-_]+)/,
-    SpotifyEpisodeRegex: /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?episode\/(?<identifier>[a-zA-Z0-9-_]+)/,
-    SpotifyShowRegex: /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?show\/(?<identifier>[a-zA-Z0-9-_]+)/,
-    SpotifyAlbumRegex: /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?album\/(?<identifier>[a-zA-Z0-9-_]+)/,
-    AllSpotifyRegex: /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?(?<type>track|album|playlist|artist|episode|show)\/(?<identifier>[a-zA-Z0-9-_]+)/,
-    
+    AllDeezerRegexWithoutPageLink:
+      /(https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?(track|playlist|album|artist|mixes\/genre|episode)\/(\d+)/,
+    AllDeezerRegex:
+      /((https?:\/\/|)?(?:www\.)?deezer\.com\/(?:\w{2}\/)?(track|playlist|album|artist|mixes\/genre|episode)\/(\d+)|(https?:\/\/|)?(?:www\.)?deezer\.page\.link\/(\S+))/,
+
+    SpotifySongRegex:
+      /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?track\/(?<identifier>[a-zA-Z0-9-_]+)/,
+    SpotifyPlaylistRegex:
+      /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?playlist\/(?<identifier>[a-zA-Z0-9-_]+)/,
+    SpotifyArtistRegex:
+      /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?artist\/(?<identifier>[a-zA-Z0-9-_]+)/,
+    SpotifyEpisodeRegex:
+      /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?episode\/(?<identifier>[a-zA-Z0-9-_]+)/,
+    SpotifyShowRegex:
+      /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?show\/(?<identifier>[a-zA-Z0-9-_]+)/,
+    SpotifyAlbumRegex:
+      /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?album\/(?<identifier>[a-zA-Z0-9-_]+)/,
+    AllSpotifyRegex:
+      /(https?:\/\/)(www\.)?open\.spotify\.com\/((?<region>[a-zA-Z-]+)\/)?(user\/(?<user>[a-zA-Z0-9-_]+)\/)?(?<type>track|album|playlist|artist|episode|show)\/(?<identifier>[a-zA-Z0-9-_]+)/,
+
     mp3Url: /(https?|ftp|file):\/\/(www.)?(.*?)\.(mp3)$/,
     m3uUrl: /(https?|ftp|file):\/\/(www.)?(.*?)\.(m3u)$/,
     m3u8Url: /(https?|ftp|file):\/\/(www.)?(.*?)\.(m3u8)$/,
@@ -334,13 +458,14 @@ export class Manager extends EventEmitter {
 
     tiktok: /https:\/\/www\.tiktok\.com\//,
     mixcloud: /https:\/\/www\.mixcloud\.com\//,
-    musicYandex: /https:\/\/music\.yandex\.ru\//, 
+    musicYandex: /https:\/\/music\.yandex\.ru\//,
     radiohost: /https?:\/\/[^.\s]+\.radiohost\.de\/(\S+)/,
     bandcamp: /https?:\/\/?(?:www\.)?([\d|\w]+)\.bandcamp\.com\/(\S+)/,
     appleMusic: /https?:\/\/?(?:www\.)?music\.apple\.com\/(\S+)/,
     TwitchTv: /https?:\/\/?(?:www\.)?twitch\.tv\/\w+/,
-    vimeo: /https?:\/\/(www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|)(\d+)(?:|\/\?)/,
-}
+    vimeo:
+      /https?:\/\/(www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|)(\d+)(?:|\/\?)/,
+  };
 
   /** The map of players. */
   public readonly players = new Collection<string, Player>();
@@ -351,12 +476,12 @@ export class Manager extends EventEmitter {
   /** If the Manager got initiated */
   public initiated = false;
 
-
-
   /** Returns the least used Nodes. */
   public get leastUsedNodes(): Collection<string, Node> {
-    if(this.options.defaultLeastUsedNodeSortType === "memory") return this.leastUsedNodesMemory;
-    else if(this.options.defaultLeastUsedNodeSortType === "calls")  return this.leastUsedNodesCalls;
+    if (this.options.defaultLeastUsedNodeSortType === "memory")
+      return this.leastUsedNodesMemory;
+    else if (this.options.defaultLeastUsedNodeSortType === "calls")
+      return this.leastUsedNodesCalls;
     else return this.leastUsedNodesPlayers; // this.options.defaultLeastUsedNodeSortType === "players"
   }
   /** Returns the least used Nodes sorted by amount of calls. */
@@ -369,35 +494,32 @@ export class Manager extends EventEmitter {
   public get leastUsedNodesPlayers(): Collection<string, Node> {
     return this.nodes
       .filter((node) => node.connected)
-       .sort((a, b) => (a.stats?.players || 0) - (b.stats?.players || 0))
+      .sort((a, b) => (a.stats?.players || 0) - (b.stats?.players || 0));
   }
   /** Returns the least used Nodes sorted by amount of memory usage. */
   public get leastUsedNodesMemory(): Collection<string, Node> {
     return this.nodes
       .filter((node) => node.connected)
-      .sort((a, b) => (b.stats?.memory?.used || 0) - (a.stats?.memory?.used || 0)) // sort after memory
+      .sort(
+        (a, b) => (b.stats?.memory?.used || 0) - (a.stats?.memory?.used || 0)
+      ); // sort after memory
   }
 
   /** Returns the least system load Nodes. */
   public get leastLoadNodes(): Collection<string, Node> {
-    if(this.options.defaultLeastLoadNodeSortType === "cpu") return this.leastLoadNodesCpu;
+    if (this.options.defaultLeastLoadNodeSortType === "cpu")
+      return this.leastLoadNodesCpu;
     else return this.leastLoadNodesMemory; // this.options.defaultLeastLoadNodeSortType === "memory"
   }
 
-
-  
   public get leastLoadNodesMemory(): Collection<string, Node> {
     return this.nodes
-            .filter((node) => node.connected)
-            .sort((a, b) => {
-            const aload = a.stats.memory?.used
-                ? a.stats.memory.used
-                : 0;
-            const bload = b.stats.memory?.used
-                ? b.stats.memory.used
-                : 0;
-            return aload - bload;
-        });
+      .filter((node) => node.connected)
+      .sort((a, b) => {
+        const aload = a.stats.memory?.used ? a.stats.memory.used : 0;
+        const bload = b.stats.memory?.used ? b.stats.memory.used : 0;
+        return aload - bload;
+      });
   }
 
   /** Returns the least system load Nodes. */
@@ -416,19 +538,22 @@ export class Manager extends EventEmitter {
   }
   /** Get FIRST valid LINK QUERY out of a string query, if it's not a valid link, then it will return undefined */
   private getValidUrlOfQuery(query: string) {
-      const args = query?.split?.(" ");
-      if(!args?.length || !Array.isArray(args)) return undefined;
-      let url;
-      for (const arg of args) {
-          try {
-              url = new URL(arg);
-              url = url.protocol === "http:" || url.protocol === "https:" ? url.href : false;
-              break;
-          } catch (_) {
-              url = undefined;
-          }
+    const args = query?.split?.(" ");
+    if (!args?.length || !Array.isArray(args)) return undefined;
+    let url;
+    for (const arg of args) {
+      try {
+        url = new URL(arg);
+        url =
+          url.protocol === "http:" || url.protocol === "https:"
+            ? url.href
+            : false;
+        break;
+      } catch (_) {
+        url = undefined;
       }
-      return url;
+    }
+    return url;
   }
   /**
    * Initiates the Manager class.
@@ -450,23 +575,26 @@ export class Manager extends EventEmitter {
 
     this.options = {
       plugins: [],
-      nodes: [{
-        identifier: "default",
-        host: "localhost",
-        port: 2333,
-        password: "youshallnotpass",
-        secure: false,
-        retryAmount: 5,
-        retryDelay: 30e3,
-        requestTimeout: 10e3,
-        version: "v3",
-        useVersionPath: true, // should be set on true, to use the latest rest api correctly!
-      }],
+      nodes: [
+        {
+          identifier: "default",
+          host: "localhost",
+          port: 2333,
+          password: "youshallnotpass",
+          secure: false,
+          retryAmount: 5,
+          retryDelay: 30e3,
+          requestTimeout: 10e3,
+          version: "v3",
+          useVersionPath: true, // should be set on true, to use the latest rest api correctly!
+        },
+      ],
       shards: 1,
       autoPlay: true,
       clientName: "erela.js",
       defaultSearchPlatform: "youtube",
-      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 OPR/93.0.0.0",
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 OPR/93.0.0.0",
       restTimeout: 5000,
       allowedLinksRegexes: [...Object.values(Manager.regex)],
       onlyAllowAllowedLinks: true,
@@ -482,7 +610,9 @@ export class Manager extends EventEmitter {
     if (this.options.plugins) {
       for (const [index, plugin] of this.options.plugins.entries()) {
         if (!(plugin instanceof Plugin) && !this.options.forceLoadPlugin)
-          throw new RangeError(`Plugin at index ${index} does not extend Plugin.`);
+          throw new RangeError(
+            `Plugin at index ${index} does not extend Plugin.`
+          );
         plugin.load(this);
       }
     }
@@ -496,32 +626,44 @@ export class Manager extends EventEmitter {
   /**
    * Initiates the Manager.
    * @param {string} clientID
-   * @param {{ clientId?: string, clientName?: string, shards?: number }} objectClientData 
+   * @param {{ clientId?: string, clientName?: string, shards?: number }} objectClientData
    */
-  public init(clientID?: string, objectClientData: { clientId?: string, clientName?: string, shards?: number } = {}): this {
+  public init(
+    clientID?: string,
+    objectClientData: {
+      clientId?: string;
+      clientName?: string;
+      shards?: number;
+    } = {}
+  ): this {
     const { clientId, clientName, shards } = objectClientData;
     if (this.initiated) return this;
     if (typeof clientId !== "undefined") this.options.clientId = clientId;
     if (typeof clientID !== "undefined") this.options.clientId = clientID;
     if (typeof clientId !== "undefined") this.options.clientId = clientId;
-    if (typeof clientName !== "undefined") this.options.clientName = clientName || `Unknown Name - ${clientId||clientID}`;
+    if (typeof clientName !== "undefined")
+      this.options.clientName =
+        clientName || `Unknown Name - ${clientId || clientID}`;
     if (typeof shards !== "undefined") this.options.shards = shards;
-    
-    if (typeof this.options.clientId !== "string") throw new Error('"clientId" set is not type of "string"');
-    if (!this.options.clientId) throw new Error('"clientId" is not set. Pass it in Manager#init() or as a option in the constructor.');
+
+    if (typeof this.options.clientId !== "string")
+      throw new Error('"clientId" set is not type of "string"');
+    if (!this.options.clientId)
+      throw new Error(
+        '"clientId" is not set. Pass it in Manager#init() or as a option in the constructor.'
+      );
 
     let success = 0;
     for (const node of this.nodes.values()) {
-        try {
-            node.connect();
-            success++;
-        }
-        catch (err) {
-            console.error(err);
-            this.emit("nodeError", node, err);
-        }
+      try {
+        node.connect();
+        success++;
+      } catch (err) {
+        console.error(err);
+        this.emit("nodeError", node, err);
+      }
     }
-    if(success > 0) this.initiated = true;
+    if (success > 0) this.initiated = true;
     else console.error("Could not connect to at least 1 Node");
 
     return this;
@@ -536,55 +678,105 @@ export class Manager extends EventEmitter {
       const node = customNode || this.leastUsedNodes.first();
       if (!node) throw new Error("No available nodes.");
 
-      const res = await node.makeRequest<LavalinkResult>(`/loadtracks?identifier=${query}`) as any;
-      if(!res) return reject(new Error("Query not found."));
-      
-      const dataArray = ([v4LoadTypes.LoadFailed, v4LoadTypes.NoMatches, LoadTypes.LoadFailed, LoadTypes.NoMatches].includes(res.loadType) 
-        ? [] // error / No matches
-        : res.loadType === v4LoadTypes.PlaylistLoaded 
+      const res = (await node.makeRequest<LavalinkResult>(
+        `/loadtracks?identifier=${query}`
+      )) as any;
+      if (!res) return reject(new Error("Query not found."));
+
+      const dataArray = (
+        [
+          v4LoadTypes.LoadFailed,
+          v4LoadTypes.NoMatches,
+          LoadTypes.LoadFailed,
+          LoadTypes.NoMatches,
+        ].includes(res.loadType)
+          ? [] // error / No matches
+          : res.loadType === v4LoadTypes.PlaylistLoaded
           ? res.data.tracks // playlist
-          : res?.[node.options?.version === "v4" ? "data" : "tracks"] && !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"]) 
-            ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]] 
-            : res?.[node.options?.version === "v4" ? "data" : "tracks"])?.filter(Boolean);
+          : res?.[node.options?.version === "v4" ? "data" : "tracks"] &&
+            !Array.isArray(
+              res?.[node.options?.version === "v4" ? "data" : "tracks"]
+            )
+          ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]]
+          : res?.[node.options?.version === "v4" ? "data" : "tracks"]
+      )?.filter(Boolean);
 
       const result: SearchResult = {
         loadType: res.loadType,
         pluginInfo: res.pluginInfo || res?.data?.pluginInfo,
         exception: res.exception ?? null,
-        tracks: dataArray?.length ? dataArray?.map((track) => TrackUtils.build(track, requester)) : [],
+        tracks: dataArray?.length
+          ? dataArray?.map((track) => TrackUtils.build(track, requester))
+          : [],
       };
 
       this.applyPlaylistInfo(result, res, node);
 
       return resolve(result);
-    })
+    });
   }
 
-  private applyPlaylistInfo(result:SearchResult, res:any, node:Node) {
+  private applyPlaylistInfo(result: SearchResult, res: any, node: Node) {
     // v4
-    if (node.options?.version === "v4" && result.loadType === v4LoadTypes.PlaylistLoaded) {
-      const selectedTrack = typeof res.data?.info?.selectedTrack !== "number" || res.data?.info?.selectedTrack === -1 ? null : result.tracks[res.data?.info?.selectedTrack];
+    if (
+      node.options?.version === "v4" &&
+      result.loadType === v4LoadTypes.PlaylistLoaded
+    ) {
+      const selectedTrack =
+        typeof res.data?.info?.selectedTrack !== "number" ||
+        res.data?.info?.selectedTrack === -1
+          ? null
+          : result.tracks[res.data?.info?.selectedTrack];
       result.playlist = {
-          name: res.data.info?.name || res.data.pluginInfo?.name || null,
-          author: res.data.info?.author || res.data.pluginInfo?.author || null,
-          thumbnail: res.data.info?.artworkUrl || res.data.pluginInfo?.artworkUrl || selectedTrack?.thumbnail || null,
-          uri: res.data.info?.url || res.data.info?.uri || res.data.info?.link || res.data.pluginInfo?.url || res.data.pluginInfo?.uri || res.data.pluginInfo?.link || null,
-          selectedTrack: selectedTrack,
-          duration: result.tracks.reduce((acc, cur) => acc + (cur?.duration || 0), 0),
-      }
-    } else if (result.loadType === LoadTypes.PlaylistLoaded || result.loadType === v4LoadTypes.PlaylistLoaded) { // v3 / v2
+        name: res.data.info?.name || res.data.pluginInfo?.name || null,
+        author: res.data.info?.author || res.data.pluginInfo?.author || null,
+        thumbnail:
+          res.data.info?.artworkUrl ||
+          res.data.pluginInfo?.artworkUrl ||
+          selectedTrack?.thumbnail ||
+          null,
+        uri:
+          res.data.info?.url ||
+          res.data.info?.uri ||
+          res.data.info?.link ||
+          res.data.pluginInfo?.url ||
+          res.data.pluginInfo?.uri ||
+          res.data.pluginInfo?.link ||
+          null,
+        selectedTrack: selectedTrack,
+        duration: result.tracks.reduce(
+          (acc, cur) => acc + (cur?.duration || 0),
+          0
+        ),
+      };
+    } else if (
+      result.loadType === LoadTypes.PlaylistLoaded ||
+      result.loadType === v4LoadTypes.PlaylistLoaded
+    ) {
+      // v3 / v2
       if (typeof res.playlistInfo === "object") {
-          const selectedTrack = typeof res.playlistInfo?.selectedTrack !== "number" || res.playlistInfo?.selectedTrack === -1 ? null : result.tracks[res.playlistInfo?.selectedTrack];
-          result.playlist = {
-              ...res.playlistInfo,
-              // transform other Data(s)
-              name: res.playlistInfo.name || null,
-              author: res.playlistInfo.author || null,
-              thumbnail: selectedTrack?.thumbnail || null,
-              uri: res.playlistInfo?.url || res.playlistInfo?.uri || res.playlistInfo?.link || null, 
-              selectedTrack: selectedTrack,
-              duration: result.tracks.reduce((acc, cur) => acc + (cur.duration || 0), 0),
-          };
+        const selectedTrack =
+          typeof res.playlistInfo?.selectedTrack !== "number" ||
+          res.playlistInfo?.selectedTrack === -1
+            ? null
+            : result.tracks[res.playlistInfo?.selectedTrack];
+        result.playlist = {
+          ...res.playlistInfo,
+          // transform other Data(s)
+          name: res.playlistInfo.name || null,
+          author: res.playlistInfo.author || null,
+          thumbnail: selectedTrack?.thumbnail || null,
+          uri:
+            res.playlistInfo?.url ||
+            res.playlistInfo?.uri ||
+            res.playlistInfo?.link ||
+            null,
+          selectedTrack: selectedTrack,
+          duration: result.tracks.reduce(
+            (acc, cur) => acc + (cur.duration || 0),
+            0
+          ),
+        };
       }
     }
   }
@@ -598,47 +790,88 @@ export class Manager extends EventEmitter {
    */
   public search(
     query: string | SearchQuery,
-    requester?: unknown, 
-    customNode?: Node,
+    requester?: unknown,
+    customNode?: Node
   ): Promise<SearchResult> {
     return new Promise(async (resolve, reject) => {
       const node = customNode || this.leastUsedNodes.first();
       if (!node) throw new Error("No available nodes.");
       const _query: SearchQuery = typeof query === "string" ? { query } : query;
-      const _source = Manager.DEFAULT_SOURCES[_query.source ?? this.options.defaultSearchPlatform] ?? _query.source ?? this.options.defaultSearchPlatform;
-      
+      const _source =
+        Manager.DEFAULT_SOURCES[
+          _query.source ?? this.options.defaultSearchPlatform
+        ] ??
+        _query.source ??
+        this.options.defaultSearchPlatform;
+
       _query.query = _query?.query?.trim?.();
 
       const link = this.getValidUrlOfQuery(_query.query);
-      if(this.options.allowedLinksRegexes?.length || this.options.allowedLinks?.length) {
-          if(link && !this.options.allowedLinksRegexes?.some(regex => regex.test(link)) && !this.options.allowedLinks?.includes(link)) reject(new Error(`Query ${_query.query} Contains link: ${link}, which is not an allowed / valid Link`));
+      if (
+        this.options.allowedLinksRegexes?.length ||
+        this.options.allowedLinks?.length
+      ) {
+        if (
+          link &&
+          !this.options.allowedLinksRegexes?.some((regex) =>
+            regex.test(link)
+          ) &&
+          !this.options.allowedLinks?.includes(link)
+        )
+          reject(
+            new Error(
+              `Query ${_query.query} Contains link: ${link}, which is not an allowed / valid Link`
+            )
+          );
       }
-      if(link && this.options.forceSearchLinkQueries) return await this.searchLink(link, requester, customNode).then(data => resolve(data)).catch(err => reject(err));
+      if (link && this.options.forceSearchLinkQueries)
+        return await this.searchLink(link, requester, customNode)
+          .then((data) => resolve(data))
+          .catch((err) => reject(err));
 
-      // only set the source, if it's not a link 
+      // only set the source, if it's not a link
       const srcSearch = !/^https?:\/\//.test(_query.query) ? `${_source}:` : "";
-            
+
       this.validatedQuery(`${srcSearch}${_query.query}`, node);
 
-      const res = await node
-        .makeRequest<LavalinkResult>(`/loadtracks?identifier=${srcSearch}${encodeURIComponent(_query.query)}`)
-        .catch(err => reject(err)) as any;
+      const res = (await node
+        .makeRequest<LavalinkResult>(
+          `/loadtracks?identifier=${srcSearch}${encodeURIComponent(
+            _query.query
+          )}`
+        )
+        .catch((err) => reject(err))) as any;
 
       if (!res) return reject(new Error("Query not found."));
-      
-      const dataArray = ([v4LoadTypes.LoadFailed, v4LoadTypes.NoMatches, LoadTypes.LoadFailed, LoadTypes.NoMatches].includes(res.loadType) 
-        ? [] // error / No matches
-        : res.loadType === v4LoadTypes.PlaylistLoaded 
+
+      const dataArray = (
+        [
+          v4LoadTypes.LoadFailed,
+          v4LoadTypes.NoMatches,
+          LoadTypes.LoadFailed,
+          LoadTypes.NoMatches,
+        ].includes(res.loadType)
+          ? [] // error / No matches
+          : res.loadType === v4LoadTypes.PlaylistLoaded
           ? res.data.tracks // playlist
-          : res?.[node.options?.version === "v4" ? "data" : "tracks"] && !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"]) 
-            ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]] 
-            : res?.[node.options?.version === "v4" ? "data" : "tracks"])?.filter(Boolean);
+          : res?.[node.options?.version === "v4" ? "data" : "tracks"] &&
+            !Array.isArray(
+              res?.[node.options?.version === "v4" ? "data" : "tracks"]
+            )
+          ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]]
+          : res?.[node.options?.version === "v4" ? "data" : "tracks"]
+      )?.filter(Boolean);
 
       const result: SearchResult = {
         loadType: res.loadType,
-        exception: res.loadType === v4LoadTypes.LoadFailed ? res.data : res.exception ?? null,
+        exception:
+          res.loadType === v4LoadTypes.LoadFailed
+            ? res.data
+            : res.exception ?? null,
         pluginInfo: res.pluginInfo ?? {},
-        tracks: dataArray?.length ? dataArray?.map((track) => TrackUtils.build(track, requester)) : [],
+        tracks: dataArray?.length
+          ? dataArray?.map((track) => TrackUtils.build(track, requester))
+          : [],
       };
 
       this.applyPlaylistInfo(result, res, node);
@@ -647,16 +880,16 @@ export class Manager extends EventEmitter {
     });
   }
   /**
-     * Searches the a link directly without any source
-     * @param query
-     * @param requester
-     * @param customNode
-     * @returns The search result.
-     */
+   * Searches the a link directly without any source
+   * @param query
+   * @param requester
+   * @param customNode
+   * @returns The search result.
+   */
   public searchLink(
     query: string | SearchQuery,
-    requester?: unknown, 
-    customNode?: Node,
+    requester?: unknown,
+    customNode?: Node
   ): Promise<SearchResult> {
     return new Promise(async (resolve, reject) => {
       const node = customNode || this.leastUsedNodes.first();
@@ -666,33 +899,61 @@ export class Manager extends EventEmitter {
       _query.query = _query?.query?.trim?.();
 
       const link = this.getValidUrlOfQuery(_query.query);
-      if(!link) return this.search(query, requester, customNode);
+      if (!link) return this.search(query, requester, customNode);
 
-      if(this.options.allowedLinksRegexes?.length || this.options.allowedLinks?.length) {
-          if(link && !this.options.allowedLinksRegexes?.some(regex => regex.test(link)) && !this.options.allowedLinks?.includes(link)) reject(new Error(`Query ${_query.query} Contains link: ${link}, which is not an allowed / valid Link`));
+      if (
+        this.options.allowedLinksRegexes?.length ||
+        this.options.allowedLinks?.length
+      ) {
+        if (
+          link &&
+          !this.options.allowedLinksRegexes?.some((regex) =>
+            regex.test(link)
+          ) &&
+          !this.options.allowedLinks?.includes(link)
+        )
+          reject(
+            new Error(
+              `Query ${_query.query} Contains link: ${link}, which is not an allowed / valid Link`
+            )
+          );
       }
-      
+
       this.validatedQuery(_query.query, node);
 
-      const res = await node
-          .makeRequest<LavalinkResult>(`/loadtracks?identifier=${encodeURIComponent(_query.query)}`)
-        .catch(err => reject(err)) as any;
+      const res = (await node
+        .makeRequest<LavalinkResult>(
+          `/loadtracks?identifier=${encodeURIComponent(_query.query)}`
+        )
+        .catch((err) => reject(err))) as any;
 
       if (!res) return reject(new Error("Query not found."));
 
-      const dataArray = ([v4LoadTypes.LoadFailed, v4LoadTypes.NoMatches, LoadTypes.LoadFailed, LoadTypes.NoMatches].includes(res.loadType) 
-        ? [] // error / No matches
-        : res.loadType === v4LoadTypes.PlaylistLoaded 
+      const dataArray = (
+        [
+          v4LoadTypes.LoadFailed,
+          v4LoadTypes.NoMatches,
+          LoadTypes.LoadFailed,
+          LoadTypes.NoMatches,
+        ].includes(res.loadType)
+          ? [] // error / No matches
+          : res.loadType === v4LoadTypes.PlaylistLoaded
           ? res.data.tracks // playlist
-          : res?.[node.options?.version === "v4" ? "data" : "tracks"] && !Array.isArray(res?.[node.options?.version === "v4" ? "data" : "tracks"]) 
-            ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]] 
-            : res?.[node.options?.version === "v4" ? "data" : "tracks"])?.filter(Boolean);
+          : res?.[node.options?.version === "v4" ? "data" : "tracks"] &&
+            !Array.isArray(
+              res?.[node.options?.version === "v4" ? "data" : "tracks"]
+            )
+          ? [res?.[node.options?.version === "v4" ? "data" : "tracks"]]
+          : res?.[node.options?.version === "v4" ? "data" : "tracks"]
+      )?.filter(Boolean);
 
       const result: SearchResult = {
         loadType: res.loadType,
         exception: res.exception ?? null,
         pluginInfo: res.pluginInfo ?? {},
-        tracks: dataArray?.length ? dataArray?.map((track) => TrackUtils.build(track, requester)) : [],
+        tracks: dataArray?.length
+          ? dataArray?.map((track) => TrackUtils.build(track, requester))
+          : [],
       };
 
       this.applyPlaylistInfo(result, res, node);
@@ -701,85 +962,179 @@ export class Manager extends EventEmitter {
     });
   }
 
-  validatedQuery(queryString:string, node:Node):void {
-    if(!node.info) return;
-    if(!node.info.sourceManagers?.length) throw new Error("Lavalink Node, has no sourceManagers enabled");
-    
+  validatedQuery(queryString: string, node: Node): void {
+    if (!node.info) return;
+    if (!node.info.sourceManagers?.length)
+      throw new Error("Lavalink Node, has no sourceManagers enabled");
+
     // missing links: beam.pro local getyarn.io clypit pornhub reddit ocreamix soundgasm
-    if((Manager.regex.YoutubeMusicRegex.test(queryString) || Manager.regex.YoutubeRegex.test(queryString)) && !node.info.sourceManagers.includes("youtube")) {
+    if (
+      (Manager.regex.YoutubeMusicRegex.test(queryString) ||
+        Manager.regex.YoutubeRegex.test(queryString)) &&
+      !node.info.sourceManagers.includes("youtube")
+    ) {
       throw new Error("Lavalink Node has not 'youtube' enabled");
     }
-    if((Manager.regex.SoundCloudMobileRegex.test(queryString) || Manager.regex.SoundCloudRegex.test(queryString)) && !node.info.sourceManagers.includes("soundcloud")) {
+    if (
+      (Manager.regex.SoundCloudMobileRegex.test(queryString) ||
+        Manager.regex.SoundCloudRegex.test(queryString)) &&
+      !node.info.sourceManagers.includes("soundcloud")
+    ) {
       throw new Error("Lavalink Node has not 'soundcloud' enabled");
     }
-    if(Manager.regex.bandcamp.test(queryString) && !node.info.sourceManagers.includes("bandcamp")) {
+    if (
+      Manager.regex.bandcamp.test(queryString) &&
+      !node.info.sourceManagers.includes("bandcamp")
+    ) {
       throw new Error("Lavalink Node has not 'bandcamp' enabled");
     }
-    if(Manager.regex.TwitchTv.test(queryString) && !node.info.sourceManagers.includes("twitch")) {
+    if (
+      Manager.regex.TwitchTv.test(queryString) &&
+      !node.info.sourceManagers.includes("twitch")
+    ) {
       throw new Error("Lavalink Node has not 'twitch' enabled");
     }
-    if(Manager.regex.vimeo.test(queryString) && !node.info.sourceManagers.includes("vimeo")) {
+    if (
+      Manager.regex.vimeo.test(queryString) &&
+      !node.info.sourceManagers.includes("vimeo")
+    ) {
       throw new Error("Lavalink Node has not 'vimeo' enabled");
     }
-    if(Manager.regex.tiktok.test(queryString) && !node.info.sourceManagers.includes("tiktok")) {
+    if (
+      Manager.regex.tiktok.test(queryString) &&
+      !node.info.sourceManagers.includes("tiktok")
+    ) {
       throw new Error("Lavalink Node has not 'tiktok' enabled");
     }
-    if(Manager.regex.mixcloud.test(queryString) && !node.info.sourceManagers.includes("mixcloud")) {
+    if (
+      Manager.regex.mixcloud.test(queryString) &&
+      !node.info.sourceManagers.includes("mixcloud")
+    ) {
       throw new Error("Lavalink Node has not 'mixcloud' enabled");
     }
-    if(Manager.regex.AllSpotifyRegex.test(queryString) && !node.info.sourceManagers.includes("spotify")) {
+    if (
+      Manager.regex.AllSpotifyRegex.test(queryString) &&
+      !node.info.sourceManagers.includes("spotify")
+    ) {
       throw new Error("Lavalink Node has not 'spotify' enabled");
     }
-    if(Manager.regex.appleMusic.test(queryString) && !node.info.sourceManagers.includes("applemusic")) {
+    if (
+      Manager.regex.appleMusic.test(queryString) &&
+      !node.info.sourceManagers.includes("applemusic")
+    ) {
       throw new Error("Lavalink Node has not 'applemusic' enabled");
     }
-    if(Manager.regex.AllDeezerRegex.test(queryString) && !node.info.sourceManagers.includes("deezer")) {
+    if (
+      Manager.regex.AllDeezerRegex.test(queryString) &&
+      !node.info.sourceManagers.includes("deezer")
+    ) {
       throw new Error("Lavalink Node has not 'deezer' enabled");
     }
-    if(Manager.regex.AllDeezerRegex.test(queryString) && node.info.sourceManagers.includes("deezer") && !node.info.sourceManagers.includes("http")) {
-      throw new Error("Lavalink Node has not 'http' enabled, which is required to have 'deezer' to work");
+    if (
+      Manager.regex.AllDeezerRegex.test(queryString) &&
+      node.info.sourceManagers.includes("deezer") &&
+      !node.info.sourceManagers.includes("http")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'http' enabled, which is required to have 'deezer' to work"
+      );
     }
-    if(Manager.regex.musicYandex.test(queryString) && !node.info.sourceManagers.includes("yandexmusic")) {
+    if (
+      Manager.regex.musicYandex.test(queryString) &&
+      !node.info.sourceManagers.includes("yandexmusic")
+    ) {
       throw new Error("Lavalink Node has not 'yandexmusic' enabled");
     }
-    
-    const hasSource = queryString.split(":")[0];
-    if(queryString.split(" ").length <= 1 || !queryString.split(" ")[0].includes(":")) return;
-    const source = Manager.DEFAULT_SOURCES[hasSource] as LavalinkSearchPlatform;
-    if(!source) throw new Error(`Lavalink Node SearchQuerySource: '${hasSource}' is not available`);
 
-    if(source === "amsearch" && !node.info.sourceManagers.includes("applemusic"))  {
-      throw new Error("Lavalink Node has not 'applemusic' enabled, which is required to have 'amsearch' work");
+    const hasSource = queryString.split(":")[0];
+    if (
+      queryString.split(" ").length <= 1 ||
+      !queryString.split(" ")[0].includes(":")
+    )
+      return;
+    const source = Manager.DEFAULT_SOURCES[hasSource] as LavalinkSearchPlatform;
+    if (!source)
+      throw new Error(
+        `Lavalink Node SearchQuerySource: '${hasSource}' is not available`
+      );
+
+    if (
+      source === "amsearch" &&
+      !node.info.sourceManagers.includes("applemusic")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'applemusic' enabled, which is required to have 'amsearch' work"
+      );
     }
-    if(source === "dzisrc" && !node.info.sourceManagers.includes("deezer"))  {
-      throw new Error("Lavalink Node has not 'deezer' enabled, which is required to have 'dzisrc' work");
+    if (source === "dzisrc" && !node.info.sourceManagers.includes("deezer")) {
+      throw new Error(
+        "Lavalink Node has not 'deezer' enabled, which is required to have 'dzisrc' work"
+      );
     }
-    if(source === "dzsearch" && !node.info.sourceManagers.includes("deezer"))  {
-      throw new Error("Lavalink Node has not 'deezer' enabled, which is required to have 'dzsearch' work");
+    if (source === "dzsearch" && !node.info.sourceManagers.includes("deezer")) {
+      throw new Error(
+        "Lavalink Node has not 'deezer' enabled, which is required to have 'dzsearch' work"
+      );
     }
-    if(source === "dzisrc" && node.info.sourceManagers.includes("deezer") && !node.info.sourceManagers.includes("http"))  {
-      throw new Error("Lavalink Node has not 'http' enabled, which is required to have 'dzisrc' to work");
+    if (
+      source === "dzisrc" &&
+      node.info.sourceManagers.includes("deezer") &&
+      !node.info.sourceManagers.includes("http")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'http' enabled, which is required to have 'dzisrc' to work"
+      );
     }
-    if(source === "dzsearch" && node.info.sourceManagers.includes("deezer") && !node.info.sourceManagers.includes("http"))  {
-      throw new Error("Lavalink Node has not 'http' enabled, which is required to have 'dzsearch' to work");
+    if (
+      source === "dzsearch" &&
+      node.info.sourceManagers.includes("deezer") &&
+      !node.info.sourceManagers.includes("http")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'http' enabled, which is required to have 'dzsearch' to work"
+      );
     }
-    if(source === "scsearch" && !node.info.sourceManagers.includes("soundcloud"))  {
-      throw new Error("Lavalink Node has not 'soundcloud' enabled, which is required to have 'scsearch' work");
+    if (
+      source === "scsearch" &&
+      !node.info.sourceManagers.includes("soundcloud")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'soundcloud' enabled, which is required to have 'scsearch' work"
+      );
     }
-    if(source === "speak" && !node.info.sourceManagers.includes("speak"))  {
-      throw new Error("Lavalink Node has not 'speak' enabled, which is required to have 'speak' work");
+    if (source === "speak" && !node.info.sourceManagers.includes("speak")) {
+      throw new Error(
+        "Lavalink Node has not 'speak' enabled, which is required to have 'speak' work"
+      );
     }
-    if(source === "tts" && !node.info.sourceManagers.includes("tts"))  {
-      throw new Error("Lavalink Node has not 'tts' enabled, which is required to have 'tts' work");
+    if (source === "tts" && !node.info.sourceManagers.includes("tts")) {
+      throw new Error(
+        "Lavalink Node has not 'tts' enabled, which is required to have 'tts' work"
+      );
     }
-    if(source === "ymsearch" && !node.info.sourceManagers.includes("yandexmusic"))  {
-      throw new Error("Lavalink Node has not 'yandexmusic' enabled, which is required to have 'ymsearch' work");
+    if (
+      source === "ymsearch" &&
+      !node.info.sourceManagers.includes("yandexmusic")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'yandexmusic' enabled, which is required to have 'ymsearch' work"
+      );
     }
-    if(source === "ytmsearch" && !node.info.sourceManagers.includes("youtube"))  {
-      throw new Error("Lavalink Node has not 'youtube' enabled, which is required to have 'ytmsearch' work");
+    if (
+      source === "ytmsearch" &&
+      !node.info.sourceManagers.includes("youtube")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'youtube' enabled, which is required to have 'ytmsearch' work"
+      );
     }
-    if(source === "ytsearch" && !node.info.sourceManagers.includes("youtube"))  {
-      throw new Error("Lavalink Node has not 'youtube' enabled, which is required to have 'ytsearch' work");
+    if (
+      source === "ytsearch" &&
+      !node.info.sourceManagers.includes("youtube")
+    ) {
+      throw new Error(
+        "Lavalink Node has not 'youtube' enabled, which is required to have 'ytsearch' work"
+      );
     }
     return;
   }
@@ -792,13 +1147,14 @@ export class Manager extends EventEmitter {
       const node = this.nodes.first();
       if (!node) throw new Error("No available nodes.");
 
-      const res = await node.makeRequest<TrackData[]>(`/decodetracks`, r => {
-        r.method = "POST";
-        r.body = JSON.stringify(tracks);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        r.headers!["Content-Type"] = "application/json";
-      })
-        .catch(err => reject(err));
+      const res = await node
+        .makeRequest<TrackData[]>(`/decodetracks`, (r) => {
+          r.method = "POST";
+          r.body = JSON.stringify(tracks);
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          r.headers!["Content-Type"] = "application/json";
+        })
+        .catch((err) => reject(err));
 
       if (!res) {
         return reject(new Error("No data returned from query."));
@@ -813,7 +1169,7 @@ export class Manager extends EventEmitter {
    * @param track
    */
   public async decodeTrack(encodedTrack: string): Promise<TrackData> {
-    const res = await this.decodeTracks([ encodedTrack ]);
+    const res = await this.decodeTracks([encodedTrack]);
     return res[0];
   }
 
@@ -864,30 +1220,38 @@ export class Manager extends EventEmitter {
   public destroyNode(identifier: string): void {
     const node = this.nodes.get(identifier);
     if (!node) return;
-    node.destroy()
-    this.nodes.delete(identifier)
+    node.destroy();
+    this.nodes.delete(identifier);
   }
 
   /**
    * Sends voice data to the Lavalink server.
    * @param data
    */
-  public async updateVoiceState(data: VoicePacket | VoiceServer | VoiceState): Promise<void> {
-    if ("t" in data && !["VOICE_STATE_UPDATE", "VOICE_SERVER_UPDATE"].includes(data.t)) return;
+  public async updateVoiceState(
+    data: VoicePacket | VoiceServer | VoiceState
+  ): Promise<void> {
+    if (
+      "t" in data &&
+      !["VOICE_STATE_UPDATE", "VOICE_SERVER_UPDATE"].includes(data.t)
+    )
+      return;
 
     const update: VoiceServer | VoiceState = "d" in data ? data.d : data;
-    if (!update || !("token" in update) && !("session_id" in update)) return;
+    if (!update || (!("token" in update) && !("session_id" in update))) return;
 
     const player = this.players.get(update.guild_id) as Player;
     if (!player) return;
-    
+
     if ("token" in update) {
       player.voiceState.event = update;
       if (!player.node?.sessionId) {
-        if (REQUIRED_KEYS.every(key => key in player.voiceState)) {
-          console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (manager-event#updateVoiceState)");
+        if (REQUIRED_KEYS.every((key) => key in player.voiceState)) {
+          console.warn(
+            "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (manager-event#updateVoiceState)"
+          );
           await player.node.send(player.voiceState);
-          return 
+          return;
         }
       }
       await player.node.updatePlayer({
@@ -897,21 +1261,21 @@ export class Manager extends EventEmitter {
             token: update.token,
             endpoint: update.endpoint,
             sessionId: player.voice?.sessionId || player.voiceState.sessionId,
-          }
-        }
+          },
+        },
       });
-      return 
+      return;
     }
 
     /* voice state update */
-    if (update.user_id !== this.options.clientId) return;      
-    
+    if (update.user_id !== this.options.clientId) return;
+
     if (update.channel_id) {
       if (player.voiceChannel !== update.channel_id) {
         this.emit("playerMove", player, player.voiceChannel, update.channel_id);
       }
-      if(player.voiceState) player.voiceState.sessionId = update.session_id;
-      if(player.voice) player.voice.sessionId = update.session_id;
+      if (player.voiceState) player.voiceState.sessionId = update.session_id;
+      if (player.voice) player.voice.sessionId = update.session_id;
       player.voiceChannel = update.channel_id;
     } else {
       this.emit("playerDisconnect", player, player.voiceChannel);
@@ -920,7 +1284,7 @@ export class Manager extends EventEmitter {
       player.voice = Object.assign({});
       await player.pause(true);
     }
-    return 
+    return;
   }
 }
 
@@ -953,7 +1317,7 @@ export interface ManagerOptions {
   /** @default "youtube" The default search platform to use, can be "youtube", "youtube music", "soundcloud", "deezer", "spotify", ... */
   defaultSearchPlatform?: SearchPlatform;
   /** used to decrement the volume to a % */
-  volumeDecrementer?: number; 
+  volumeDecrementer?: number;
   /** used to change the position_update_interval from 250ms to X ms */
   position_update_interval?: number;
   /** Extra Uris which are allowed to be saved as a unresolved from URI (only provide ones which can be handled by LAVALINK) */
@@ -991,11 +1355,73 @@ export interface ManagerOptions {
 export type leastUsedNodeSortType = "memory" | "calls" | "players";
 export type leastLoadNodeSortType = "cpu" | "memory";
 
-export type LavalinkSearchPlatform = "ytsearch" | "ytmsearch" | "scsearch" | "spsearch" | "sprec" | "amsearch" | "dzsearch" | "dzisrc" | "sprec" | "ymsearch" | "speak" | "tts";
-export type ErelaSearchPlatform = "youtube" | "youtube music" | "soundcloud" | "ytm" | "yt" | "sc" | "am" | "sp" | "sprec" | "spsuggestion" | "ds" | "dz" | "deezer" | "yandex" | "yandexmusic";
+export type LavalinkSearchPlatform =
+  | "ytsearch"
+  | "ytmsearch"
+  | "scsearch"
+  | "spsearch"
+  | "sprec"
+  | "amsearch"
+  | "dzsearch"
+  | "dzisrc"
+  | "sprec"
+  | "ymsearch"
+  | "speak"
+  | "tts";
+export type ErelaSearchPlatform =
+  | "youtube"
+  | "youtube music"
+  | "soundcloud"
+  | "ytm"
+  | "yt"
+  | "sc"
+  | "am"
+  | "sp"
+  | "sprec"
+  | "spsuggestion"
+  | "ds"
+  | "dz"
+  | "deezer"
+  | "yandex"
+  | "yandexmusic";
 export type SearchPlatform = LavalinkSearchPlatform | ErelaSearchPlatform;
 
-export type SourcesRegex = "YoutubeRegex" | "YoutubeMusicRegex" | "SoundCloudRegex" | "SoundCloudMobileRegex" | "DeezerTrackRegex" | "DeezerArtistRegex" | "DeezerEpisodeRegex" | "DeezerMixesRegex" | "DeezerPageLinkRegex" | "DeezerPlaylistRegex" | "DeezerAlbumRegex" | "AllDeezerRegex" | "AllDeezerRegexWithoutPageLink" | "SpotifySongRegex" | "SpotifyPlaylistRegex" | "SpotifyArtistRegex" | "SpotifyEpisodeRegex" | "SpotifyShowRegex" | "SpotifyAlbumRegex" | "AllSpotifyRegex" | "mp3Url" | "m3uUrl" | "m3u8Url" | "mp4Url" | "m4aUrl" | "wavUrl" | "aacpUrl" | "tiktok" | "mixcloud" | "musicYandex" | "radiohost" | "bandcamp" | "appleMusic" | "TwitchTv" | "vimeo"
+export type SourcesRegex =
+  | "YoutubeRegex"
+  | "YoutubeMusicRegex"
+  | "SoundCloudRegex"
+  | "SoundCloudMobileRegex"
+  | "DeezerTrackRegex"
+  | "DeezerArtistRegex"
+  | "DeezerEpisodeRegex"
+  | "DeezerMixesRegex"
+  | "DeezerPageLinkRegex"
+  | "DeezerPlaylistRegex"
+  | "DeezerAlbumRegex"
+  | "AllDeezerRegex"
+  | "AllDeezerRegexWithoutPageLink"
+  | "SpotifySongRegex"
+  | "SpotifyPlaylistRegex"
+  | "SpotifyArtistRegex"
+  | "SpotifyEpisodeRegex"
+  | "SpotifyShowRegex"
+  | "SpotifyAlbumRegex"
+  | "AllSpotifyRegex"
+  | "mp3Url"
+  | "m3uUrl"
+  | "m3u8Url"
+  | "mp4Url"
+  | "m4aUrl"
+  | "wavUrl"
+  | "aacpUrl"
+  | "tiktok"
+  | "mixcloud"
+  | "musicYandex"
+  | "radiohost"
+  | "bandcamp"
+  | "appleMusic"
+  | "TwitchTv"
+  | "vimeo";
 
 export interface SearchQuery {
   /** The source to search from. */
@@ -1012,7 +1438,7 @@ export interface SearchResult {
   /** The playlist info if the load type is PLAYLIST_LOADED. */
   playlist?: PlaylistInfo;
   /** The plugin info if the load type is PLAYLIST_LOADED. */
-  pluginInfo?: Partial<PluginDataInfo> | Record<string, string|number>;
+  pluginInfo?: Partial<PluginDataInfo> | Record<string, string | number>;
   /** The exception when searching if one. */
   exception?: {
     /** The message for the exception. */
@@ -1037,26 +1463,24 @@ export interface PlaylistInfo {
   duration: number;
 }
 
-
-
 export interface LavalinkResult {
   // result from v3 / v2
   tracks?: TrackData[];
   // or if result is via v4:
-  data?: TrackData[] /* on search query */
-  | TrackData  /* on link result */
-  | { tracks: TrackData[] }, /* on playlist result */
+  data?:
+    | TrackData[] /* on search query */
+    | TrackData /* on link result */
+    | { tracks: TrackData[] } /* on playlist result */;
   loadType: LoadType | v4LoadType;
   exception?: {
     /** The message for the exception. */
     message: string;
     /** The severity of exception. */
     severity: string;
-
   };
   playlistInfo: {
     name: string;
     selectedTrack?: number;
   } | null;
-  pluginInfo: Partial<PluginDataInfo> | Record<string, string|number> | null;
+  pluginInfo: Partial<PluginDataInfo> | Record<string, string | number> | null;
 }

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -1,37 +1,53 @@
-import { LavalinkSearchPlatform, Manager, SearchQuery, SearchResult } from "./Manager";
+import {
+  LavalinkSearchPlatform,
+  Manager,
+  SearchQuery,
+  SearchResult,
+} from "./Manager";
 import { Node } from "./Node";
 import { Queue } from "./Queue";
-import { LavalinkFilterData, LavalinkPlayerVoice, TimescaleFilter } from "./Utils";
-import { State, Structure, TrackUtils, VoiceState } from "./Utils";
+import {
+  LavalinkFilterData,
+  LavalinkPlayerVoice,
+  State,
+  Structure,
+  TimescaleFilter,
+  TrackUtils,
+  VoiceState,
+} from "./Utils";
 
 export type AudioOutputs = "mono" | "stereo" | "left" | "right";
 
 export const validAudioOutputs = {
-  mono: { // totalLeft: 1, totalRight: 1
-      leftToLeft: 0.5, //each channel should in total 0 | 1, 0 === off, 1 === on, 0.5+0.5 === 1
-      leftToRight: 0.5,
-      rightToLeft: 0.5,
-      rightToRight: 0.5,
+  mono: {
+    // totalLeft: 1, totalRight: 1
+    leftToLeft: 0.5, //each channel should in total 0 | 1, 0 === off, 1 === on, 0.5+0.5 === 1
+    leftToRight: 0.5,
+    rightToLeft: 0.5,
+    rightToRight: 0.5,
   },
-  stereo: { // totalLeft: 1, totalRight: 1
-      leftToLeft: 1,
-      leftToRight: 0,
-      rightToLeft: 0,
-      rightToRight: 1,
+  stereo: {
+    // totalLeft: 1, totalRight: 1
+    leftToLeft: 1,
+    leftToRight: 0,
+    rightToLeft: 0,
+    rightToRight: 1,
   },
-  left: { // totalLeft: 1, totalRight: 0
-      leftToLeft: 0.5,
-      leftToRight: 0,
-      rightToLeft: 0.5,
-      rightToRight: 0,
+  left: {
+    // totalLeft: 1, totalRight: 0
+    leftToLeft: 0.5,
+    leftToRight: 0,
+    rightToLeft: 0.5,
+    rightToRight: 0,
   },
-  right: { // totalLeft: 0, totalRight: 1
-      leftToLeft: 0,
-      leftToRight: 0.5,
-      rightToLeft: 0,
-      rightToRight: 0.5,
+  right: {
+    // totalLeft: 0, totalRight: 1
+    leftToLeft: 0,
+    leftToRight: 0.5,
+    rightToLeft: 0,
+    rightToRight: 0.5,
   },
-}
+};
 function check(options: PlayerOptions) {
   if (!options) throw new TypeError("PlayerOptions must not be empty.");
 
@@ -73,13 +89,13 @@ function check(options: PlayerOptions) {
 }
 
 export interface PlayerUpdatePayload {
-  state: { 
-      connected: boolean, 
-      ping: number, 
-      position: number, 
-      time: number
-  },
-  guildId: string
+  state: {
+    connected: boolean;
+    ping: number;
+    position: number;
+    time: number;
+  };
+  guildId: string;
 }
 export interface PlayerFilters {
   /** Sets nightcore to false, and vaporwave to false */
@@ -88,13 +104,13 @@ export interface PlayerFilters {
   nightcore: boolean;
   /** Sets custom to false, and nightcore to false */
   vaporwave: boolean;
-  /** only with the custom lavalink filter plugin */ 
+  /** only with the custom lavalink filter plugin */
   echo: boolean;
-  /** only with the custom lavalink filter plugin */ 
+  /** only with the custom lavalink filter plugin */
   reverb: boolean;
   rotation: boolean;
   /** @deprecated */
-  rotating: boolean; 
+  rotating: boolean;
   karaoke: boolean;
   tremolo: boolean;
   vibrato: boolean;
@@ -144,19 +160,19 @@ export class Player {
   /** Checker if filters should be updated or not! */
   public filterUpdated: number;
   /** When the player was created [Date] (from lavalink) */
-  public createdAt: Date|null;
+  public createdAt: Date | null;
   /** When the player was created [Timestamp] (from lavalink) */
   public createdTimeStamp: number;
   /** If lavalink says it's connected or not */
-  public connected: boolean|undefined;
+  public connected: boolean | undefined;
   /** Last sent payload from lavalink */
   public payload: Partial<PlayerUpdatePayload>;
   /** A Voice-Region for voice-regioned based - Node identification(s) */
   public region: string;
   /** The Ping to the Lavalink Client in ms | < 0 == not connected | undefined == not defined yet. */
-  public ping: number|undefined;
+  public ping: number | undefined;
   /** The Voice Connection Ping from Lavalink in ms | < 0 == not connected | null == lavalinkversion is < 3.5.1 in where there is no ping info. | undefined == not defined yet. */
-  public wsPing: number|null|undefined;
+  public wsPing: number | null | undefined;
   /** All States of a Filter, however you can manually overwrite it with a string, if you need so */
   public filters: PlayerFilters;
   /** The Current Filter Data(s) */
@@ -205,40 +221,47 @@ export class Player {
     /** If lavalink says it's connected or not */
     this.connected = undefined;
     /** Last sent payload from lavalink */
-    this.payload = { };
+    this.payload = {};
     /** Ping to Lavalink from Client */
     this.ping = undefined;
     /** The Voice Connection Ping from Lavalink */
-    this.wsPing = undefined,
-    
-    /** The equalizer bands array. */
-    this.bands = new Array(15).fill(0.0);
+    (this.wsPing = undefined),
+      /** The equalizer bands array. */
+      (this.bands = new Array(15).fill(0.0));
     this.set("lastposition", undefined);
-    
-    if(typeof options.customData === "object" && Object.keys(options.customData).length) {
+
+    if (
+      typeof options.customData === "object" &&
+      Object.keys(options.customData).length
+    ) {
       this.data = { ...this.data, ...options.customData };
-    } 
+    }
 
     this.guild = options.guild;
-    this.voiceState = Object.assign({ op: "voiceUpdate", guildId: options.guild });
+    this.voiceState = Object.assign({
+      op: "voiceUpdate",
+      guildId: options.guild,
+    });
 
     if (options.voiceChannel) this.voiceChannel = options.voiceChannel;
     if (options.textChannel) this.textChannel = options.textChannel;
-    if(typeof options.instaUpdateFiltersFix === "undefined") this.options.instaUpdateFiltersFix = true;
+    if (typeof options.instaUpdateFiltersFix === "undefined")
+      this.options.instaUpdateFiltersFix = true;
 
-    if(!this.manager.leastUsedNodes?.size) {
-      if(this.manager.initiated) this.manager.initiated = false; 
+    if (!this.manager.leastUsedNodes?.size) {
+      if (this.manager.initiated) this.manager.initiated = false;
       this.manager.init(this.manager.options?.clientId);
     }
-  
+
     this.region = options?.region;
     const customNode = this.manager.nodes.get(options.node);
-    const regionNode = this.manager.leastUsedNodes.filter(x => x.regions?.includes(options.region?.toLowerCase()))?.first();
-    this.node = customNode || regionNode || this.manager.leastUsedNodes.first()
+    const regionNode = this.manager.leastUsedNodes
+      .filter((x) => x.regions?.includes(options.region?.toLowerCase()))
+      ?.first();
+    this.node = customNode || regionNode || this.manager.leastUsedNodes.first();
 
     if (!this.node) throw new RangeError("No available nodes.");
 
-        
     this.filters = {
       volume: false,
       vaporwave: false,
@@ -247,46 +270,46 @@ export class Player {
       echo: false,
       reverb: false,
       rotating: false,
-      rotation: false, 
+      rotation: false,
       karaoke: false,
       tremolo: false,
       vibrato: false,
       lowPass: false,
       audioOutput: "stereo",
-  } 
-  this.filterData = { 
+    };
+    this.filterData = {
       lowPass: {
-          smoothing: 0
+        smoothing: 0,
       },
       karaoke: {
-          level: 0,
-          monoLevel: 0,
-          filterBand: 0,
-          filterWidth: 0
+        level: 0,
+        monoLevel: 0,
+        filterBand: 0,
+        filterWidth: 0,
       },
       timescale: {
-          speed: 1, // 0 = x
-          pitch: 1, // 0 = x
-          rate: 1 // 0 = x
+        speed: 1, // 0 = x
+        pitch: 1, // 0 = x
+        rate: 1, // 0 = x
       },
       echo: {
-          delay: 0,
-          decay: 0
+        delay: 0,
+        decay: 0,
       },
       reverb: {
-          delay: 0,
-          decay: 0
+        delay: 0,
+        decay: 0,
       },
       rotation: {
-          rotationHz: 0
+        rotationHz: 0,
       },
       tremolo: {
-          frequency: 2, // 0 < x
-          depth: 0.1 // 0 < x = 1
+        frequency: 2, // 0 < x
+        depth: 0.1, // 0 < x = 1
       },
       vibrato: {
-          frequency: 2, // 0 < x = 14
-          depth: 0.1      // 0 < x = 1
+        frequency: 2, // 0 < x = 14
+        depth: 0.1, // 0 < x = 1
       },
       channelMix: validAudioOutputs.stereo,
       /*distortion: {
@@ -299,23 +322,40 @@ export class Player {
           offset: 0,
           scale: 1
       }*/
-    }
+    };
 
     this.manager.players.set(options.guild, this);
     this.manager.emit("playerCreate", this);
     this.setVolume(options.volume ?? 100);
   }
-  checkFiltersState(oldFilterTimescale?:Partial<TimescaleFilter>) {
+  checkFiltersState(oldFilterTimescale?: Partial<TimescaleFilter>) {
     this.filters.rotation = this.filterData.rotation.rotationHz !== 0;
-    this.filters.vibrato = this.filterData.vibrato.frequency !== 0 || this.filterData.vibrato.depth !== 0;
-    this.filters.tremolo = this.filterData.tremolo.frequency !== 0 || this.filterData.tremolo.depth !== 0;
-    this.filters.echo = this.filterData.echo.decay !== 0 || this.filterData.echo.delay !== 0;
-    this.filters.reverb = this.filterData.reverb.decay !== 0 || this.filterData.reverb.delay !== 0;
+    this.filters.vibrato =
+      this.filterData.vibrato.frequency !== 0 ||
+      this.filterData.vibrato.depth !== 0;
+    this.filters.tremolo =
+      this.filterData.tremolo.frequency !== 0 ||
+      this.filterData.tremolo.depth !== 0;
+    this.filters.echo =
+      this.filterData.echo.decay !== 0 || this.filterData.echo.delay !== 0;
+    this.filters.reverb =
+      this.filterData.reverb.decay !== 0 || this.filterData.reverb.delay !== 0;
     this.filters.lowPass = this.filterData.lowPass.smoothing !== 0;
-    this.filters.karaoke = Object.values(this.filterData.karaoke).some(v => v !== 0);
-    if((this.filters.nightcore || this.filters.vaporwave) && oldFilterTimescale) {
-      if(oldFilterTimescale.pitch !== this.filterData.timescale.pitch || oldFilterTimescale.rate !== this.filterData.timescale.rate || oldFilterTimescale.speed !== this.filterData.timescale.speed) {
-        this.filters.custom = Object.values(this.filterData.timescale).some(v => v !== 1);
+    this.filters.karaoke = Object.values(this.filterData.karaoke).some(
+      (v) => v !== 0
+    );
+    if (
+      (this.filters.nightcore || this.filters.vaporwave) &&
+      oldFilterTimescale
+    ) {
+      if (
+        oldFilterTimescale.pitch !== this.filterData.timescale.pitch ||
+        oldFilterTimescale.rate !== this.filterData.timescale.rate ||
+        oldFilterTimescale.speed !== this.filterData.timescale.speed
+      ) {
+        this.filters.custom = Object.values(this.filterData.timescale).some(
+          (v) => v !== 1
+        );
         this.filters.nightcore = false;
         this.filters.vaporwave = false;
       }
@@ -326,7 +366,7 @@ export class Player {
   /**
    * Reset all Filters
    */
-  public async resetFilters() : Promise<PlayerFilters> {
+  public async resetFilters(): Promise<PlayerFilters> {
     this.filters.echo = false;
     this.filters.reverb = false;
     this.filters.nightcore = false;
@@ -340,55 +380,59 @@ export class Player {
     this.filters.volume = false;
     this.filters.audioOutput = "stereo";
     // disable all filters
-    for(const [key, value] of Object.entries({
-        volume: 1,
-        lowPass: {
-            smoothing: 0
-        },
-        karaoke: {
-            level: 0,
-            monoLevel: 0,
-            filterBand: 0,
-            filterWidth: 0
-        },
-        timescale: {
-            speed: 1, // 0 = x
-            pitch: 1, // 0 = x
-            rate: 1 // 0 = x
-        },
-        echo: {
-            delay: 0,
-            decay: 0
-        },
-        reverb: {
-            delay: 0,
-            decay: 0
-        },
-        rotation: {
-            rotationHz: 0
-        },
-        tremolo: {
-            frequency: 2, // 0 < x
-            depth: 0.1 // 0 < x = 1
-        },
-        vibrato: {
-            frequency: 2, // 0 < x = 14
-            depth: 0.1      // 0 < x = 1
-        },
-        channelMix: validAudioOutputs.stereo,
+    for (const [key, value] of Object.entries({
+      volume: 1,
+      lowPass: {
+        smoothing: 0,
+      },
+      karaoke: {
+        level: 0,
+        monoLevel: 0,
+        filterBand: 0,
+        filterWidth: 0,
+      },
+      timescale: {
+        speed: 1, // 0 = x
+        pitch: 1, // 0 = x
+        rate: 1, // 0 = x
+      },
+      echo: {
+        delay: 0,
+        decay: 0,
+      },
+      reverb: {
+        delay: 0,
+        decay: 0,
+      },
+      rotation: {
+        rotationHz: 0,
+      },
+      tremolo: {
+        frequency: 2, // 0 < x
+        depth: 0.1, // 0 < x = 1
+      },
+      vibrato: {
+        frequency: 2, // 0 < x = 14
+        depth: 0.1, // 0 < x = 1
+      },
+      channelMix: validAudioOutputs.stereo,
     })) {
-        this.filterData[key] = value;
+      this.filterData[key] = value;
     }
     await this.updatePlayerFilters();
     return this.filters;
   }
   /**
-   * Set the AudioOutput Filter 
-   * @param type 
+   * Set the AudioOutput Filter
+   * @param type
    */
-  public async setAudioOutput(type:AudioOutputs): Promise<AudioOutputs> {
-    if(this.node.info && !this.node.info?.filters?.includes("channelMix")) throw new Error("Node#Info#filters does not include the 'channelMix' Filter (Node has it not enable)")
-    if(!type || !validAudioOutputs[type]) throw "Invalid audio type added, must be 'mono' / 'stereo' / 'left' / 'right'"
+  public async setAudioOutput(type: AudioOutputs): Promise<AudioOutputs> {
+    if (this.node.info && !this.node.info?.filters?.includes("channelMix"))
+      throw new Error(
+        "Node#Info#filters does not include the 'channelMix' Filter (Node has it not enable)"
+      );
+    if (!type || !validAudioOutputs[type])
+      throw "Invalid audio type added, must be 'mono' / 'stereo' / 'left' / 'right'";
     this.filterData.channelMix = validAudioOutputs[type];
     this.filters.audioOutput = type;
     await this.updatePlayerFilters();
@@ -396,13 +440,16 @@ export class Player {
   }
   /**
    * Set custom filter.timescale#speed . This method disabled both: nightcore & vaporwave. use 1 to reset it to normal
-   * @param speed 
-   * @returns 
+   * @param speed
+   * @returns
    */
   public async setSpeed(speed = 1): Promise<boolean> {
-    if(this.node.info && !this.node.info?.filters?.includes("timescale")) throw new Error("Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)")
+    if (this.node.info && !this.node.info?.filters?.includes("timescale"))
+      throw new Error(
+        "Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)"
+      );
     // reset nightcore / vaporwave filter if enabled
-    if(this.filters.nightcore || this.filters.vaporwave) { 
+    if (this.filters.nightcore || this.filters.vaporwave) {
       this.filterData.timescale.pitch = 1;
       this.filterData.timescale.speed = 1;
       this.filterData.timescale.rate = 1;
@@ -414,19 +461,22 @@ export class Player {
 
     // check if custom filter is active / not
     this.isCustomFilterActive();
-    
+
     await this.updatePlayerFilters();
     return this.filters.custom;
   }
   /**
    * Set custom filter.timescale#pitch . This method disabled both: nightcore & vaporwave. use 1 to reset it to normal
-   * @param speed 
-   * @returns 
+   * @param speed
+   * @returns
    */
   public async setPitch(pitch = 1): Promise<boolean> {
-    if(this.node.info && !this.node.info?.filters?.includes("timescale")) throw new Error("Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)")
+    if (this.node.info && !this.node.info?.filters?.includes("timescale"))
+      throw new Error(
+        "Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)"
+      );
     // reset nightcore / vaporwave filter if enabled
-    if(this.filters.nightcore || this.filters.vaporwave) { 
+    if (this.filters.nightcore || this.filters.vaporwave) {
       this.filterData.timescale.pitch = 1;
       this.filterData.timescale.speed = 1;
       this.filterData.timescale.rate = 1;
@@ -436,7 +486,6 @@ export class Player {
 
     this.filterData.timescale.pitch = pitch;
 
-
     // check if custom filter is active / not
     this.isCustomFilterActive();
 
@@ -445,13 +494,16 @@ export class Player {
   }
   /**
    * Set custom filter.timescale#rate . This method disabled both: nightcore & vaporwave. use 1 to reset it to normal
-   * @param speed 
-   * @returns 
+   * @param speed
+   * @returns
    */
-  public async setRate(rate = 1): Promise<boolean> {    
-    if(this.node.info && !this.node.info?.filters?.includes("timescale")) throw new Error("Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)")
+  public async setRate(rate = 1): Promise<boolean> {
+    if (this.node.info && !this.node.info?.filters?.includes("timescale"))
+      throw new Error(
+        "Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)"
+      );
     // reset nightcore / vaporwave filter if enabled
-    if(this.filters.nightcore || this.filters.vaporwave) { 
+    if (this.filters.nightcore || this.filters.vaporwave) {
       this.filterData.timescale.pitch = 1;
       this.filterData.timescale.speed = 1;
       this.filterData.timescale.rate = 1;
@@ -469,212 +521,267 @@ export class Player {
   /**
    * Enabels / Disables the rotation effect, (Optional: provide your Own Data)
    * @param rotationHz
-   * @returns 
+   * @returns
    */
   public async toggleRotation(rotationHz = 0.2): Promise<boolean> {
-    if(this.node.info && !this.node.info?.filters?.includes("rotation")) throw new Error("Node#Info#filters does not include the 'rotation' Filter (Node has it not enable)")
-    this.filterData.rotation.rotationHz = this.filters.rotation ? 0 : rotationHz;
-    
+    if (this.node.info && !this.node.info?.filters?.includes("rotation"))
+      throw new Error(
+        "Node#Info#filters does not include the 'rotation' Filter (Node has it not enable)"
+      );
+    this.filterData.rotation.rotationHz = this.filters.rotation
+      ? 0
+      : rotationHz;
+
     this.filters.rotation = !this.filters.rotation;
     /** @deprecated but sync with rotating */
     this.filters.rotating = this.filters.rotation;
-    
+
     return await this.updatePlayerFilters(), this.filters.rotation;
   }
   /**
    * @deprected - use #toggleRotation() Enabels / Disables the rotation effect, (Optional: provide your Own Data)
    * @param rotationHz
-   * @returns 
+   * @returns
    */
   public async toggleRotating(rotationHz = 0.2): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("rotation")) throw new Error("Node#Info#filters does not include the 'rotation' Filter (Node has it not enable)")
-      this.filterData.rotation.rotationHz = this.filters.rotation ? 0 : rotationHz;
-      
-      this.filters.rotation = !this.filters.rotation;
-      /** @deprecated but sync with rotating */
-      this.filters.rotating = this.filters.rotation;
-      
-      return await this.updatePlayerFilters(), this.filters.rotation;
+    if (this.node.info && !this.node.info?.filters?.includes("rotation"))
+      throw new Error(
+        "Node#Info#filters does not include the 'rotation' Filter (Node has it not enable)"
+      );
+    this.filterData.rotation.rotationHz = this.filters.rotation
+      ? 0
+      : rotationHz;
+
+    this.filters.rotation = !this.filters.rotation;
+    /** @deprecated but sync with rotating */
+    this.filters.rotating = this.filters.rotation;
+
+    return await this.updatePlayerFilters(), this.filters.rotation;
   }
   /**
    * Enabels / Disables the Vibrato effect, (Optional: provide your Own Data)
    * @param frequency
    * @param depth
-   * @returns 
+   * @returns
    */
   public async toggleVibrato(frequency = 2, depth = 0.5): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("vibrato")) throw new Error("Node#Info#filters does not include the 'vibrato' Filter (Node has it not enable)")
-      this.filterData.vibrato.frequency = this.filters.vibrato ? 0 : frequency;
-      this.filterData.vibrato.depth = this.filters.vibrato ? 0 : depth;
+    if (this.node.info && !this.node.info?.filters?.includes("vibrato"))
+      throw new Error(
+        "Node#Info#filters does not include the 'vibrato' Filter (Node has it not enable)"
+      );
+    this.filterData.vibrato.frequency = this.filters.vibrato ? 0 : frequency;
+    this.filterData.vibrato.depth = this.filters.vibrato ? 0 : depth;
 
-      this.filters.vibrato = !this.filters.vibrato;
-      await this.updatePlayerFilters();
-      return this.filters.vibrato;
+    this.filters.vibrato = !this.filters.vibrato;
+    await this.updatePlayerFilters();
+    return this.filters.vibrato;
   }
   /**
    * Enabels / Disables the Tremolo effect, (Optional: provide your Own Data)
    * @param frequency
    * @param depth
-   * @returns 
+   * @returns
    */
   public async toggleTremolo(frequency = 2, depth = 0.5): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("tremolo")) throw new Error("Node#Info#filters does not include the 'tremolo' Filter (Node has it not enable)")
-      this.filterData.tremolo.frequency = this.filters.tremolo ? 0 : frequency;
-      this.filterData.tremolo.depth = this.filters.tremolo ? 0 : depth;
+    if (this.node.info && !this.node.info?.filters?.includes("tremolo"))
+      throw new Error(
+        "Node#Info#filters does not include the 'tremolo' Filter (Node has it not enable)"
+      );
+    this.filterData.tremolo.frequency = this.filters.tremolo ? 0 : frequency;
+    this.filterData.tremolo.depth = this.filters.tremolo ? 0 : depth;
 
-      this.filters.tremolo = !this.filters.tremolo;
-      await this.updatePlayerFilters()
-      return this.filters.tremolo;
+    this.filters.tremolo = !this.filters.tremolo;
+    await this.updatePlayerFilters();
+    return this.filters.tremolo;
   }
   /**
    * Enabels / Disables the LowPass effect, (Optional: provide your Own Data)
    * @param smoothing
-   * @returns 
+   * @returns
    */
   public async toggleLowPass(smoothing = 20): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("lowPass")) throw new Error("Node#Info#filters does not include the 'lowPass' Filter (Node has it not enable)")
-      this.filterData.lowPass.smoothing = this.filters.lowPass ? 0 : smoothing;
-      
-      this.filters.lowPass = !this.filters.lowPass;
-      await this.updatePlayerFilters();
-      return this.filters.lowPass;
+    if (this.node.info && !this.node.info?.filters?.includes("lowPass"))
+      throw new Error(
+        "Node#Info#filters does not include the 'lowPass' Filter (Node has it not enable)"
+      );
+    this.filterData.lowPass.smoothing = this.filters.lowPass ? 0 : smoothing;
+
+    this.filters.lowPass = !this.filters.lowPass;
+    await this.updatePlayerFilters();
+    return this.filters.lowPass;
   }
   /**
    * Enabels / Disables the Echo effect, IMPORTANT! Only works with the correct Lavalink Plugin installed. (Optional: provide your Own Data)
    * @param delay
    * @param decay
-   * @returns 
+   * @returns
    */
   public async toggleEcho(delay = 1, decay = 0.5): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("echo")) throw new Error("Node#Info#filters does not include the 'echo' Filter (Node has it not enable aka not installed!)")
-      this.filterData.echo.delay = this.filters.echo ? 0 : delay;
-      this.filterData.echo.decay = this.filters.echo ? 0 : decay;
+    if (this.node.info && !this.node.info?.filters?.includes("echo"))
+      throw new Error(
+        "Node#Info#filters does not include the 'echo' Filter (Node has it not enable aka not installed!)"
+      );
+    this.filterData.echo.delay = this.filters.echo ? 0 : delay;
+    this.filterData.echo.decay = this.filters.echo ? 0 : decay;
 
-      this.filters.echo = !this.filters.echo;
-      await this.updatePlayerFilters();
-      return this.filters.echo;
+    this.filters.echo = !this.filters.echo;
+    await this.updatePlayerFilters();
+    return this.filters.echo;
   }
   /**
    * Enabels / Disables the Echo effect, IMPORTANT! Only works with the correct Lavalink Plugin installed. (Optional: provide your Own Data)
    * @param delay
    * @param decay
-   * @returns 
+   * @returns
    */
   public async toggleReverb(delay = 1, decay = 0.5): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("reverb")) throw new Error("Node#Info#filters does not include the 'reverb' Filter (Node has it not enable aka not installed!)")
-      this.filterData.reverb.delay = this.filters.reverb ? 0 : delay;
-      this.filterData.reverb.decay = this.filters.reverb ? 0 : decay;
+    if (this.node.info && !this.node.info?.filters?.includes("reverb"))
+      throw new Error(
+        "Node#Info#filters does not include the 'reverb' Filter (Node has it not enable aka not installed!)"
+      );
+    this.filterData.reverb.delay = this.filters.reverb ? 0 : delay;
+    this.filterData.reverb.decay = this.filters.reverb ? 0 : decay;
 
-      this.filters.reverb = !this.filters.reverb;
-      await this.updatePlayerFilters();
-      return this.filters.reverb;
+    this.filters.reverb = !this.filters.reverb;
+    await this.updatePlayerFilters();
+    return this.filters.reverb;
   }
   /**
    * Enables / Disabels a Nightcore-like filter Effect. Disables/Overwrides both: custom and Vaporwave Filter
-   * @param speed 
-   * @param pitch 
-   * @param rate 
-   * @returns 
+   * @param speed
+   * @param pitch
+   * @param rate
+   * @returns
    */
-  public async toggleNightcore(speed = 1.289999523162842, pitch = 1.289999523162842, rate = 0.9365999523162842): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("timescale")) throw new Error("Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)")
-      this.filterData.timescale.speed = this.filters.nightcore ? 1 : speed;
-      this.filterData.timescale.pitch = this.filters.nightcore ? 1 : pitch;
-      this.filterData.timescale.rate = this.filters.nightcore ? 1 : rate;
+  public async toggleNightcore(
+    speed = 1.289999523162842,
+    pitch = 1.289999523162842,
+    rate = 0.9365999523162842
+  ): Promise<boolean> {
+    if (this.node.info && !this.node.info?.filters?.includes("timescale"))
+      throw new Error(
+        "Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)"
+      );
+    this.filterData.timescale.speed = this.filters.nightcore ? 1 : speed;
+    this.filterData.timescale.pitch = this.filters.nightcore ? 1 : pitch;
+    this.filterData.timescale.rate = this.filters.nightcore ? 1 : rate;
 
-      this.filters.nightcore = !this.filters.nightcore;
-      this.filters.vaporwave = false;
-      this.filters.custom = false;
-      await this.updatePlayerFilters();
-      return this.filters.nightcore;
+    this.filters.nightcore = !this.filters.nightcore;
+    this.filters.vaporwave = false;
+    this.filters.custom = false;
+    await this.updatePlayerFilters();
+    return this.filters.nightcore;
   }
   /**
    * Enables / Disabels a Vaporwave-like filter Effect. Disables/Overwrides both: custom and nightcore Filter
-   * @param speed 
-   * @param pitch 
-   * @param rate 
-   * @returns 
+   * @param speed
+   * @param pitch
+   * @param rate
+   * @returns
    */
-  public async toggleVaporwave(speed = 0.8500000238418579, pitch = 0.800000011920929, rate = 1): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("timescale")) throw new Error("Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)")
-      this.filterData.timescale.speed = this.filters.vaporwave ? 1 : speed;
-      this.filterData.timescale.pitch = this.filters.vaporwave ? 1 : pitch;
-      this.filterData.timescale.rate = this.filters.vaporwave ? 1 : rate;
+  public async toggleVaporwave(
+    speed = 0.8500000238418579,
+    pitch = 0.800000011920929,
+    rate = 1
+  ): Promise<boolean> {
+    if (this.node.info && !this.node.info?.filters?.includes("timescale"))
+      throw new Error(
+        "Node#Info#filters does not include the 'timescale' Filter (Node has it not enable)"
+      );
+    this.filterData.timescale.speed = this.filters.vaporwave ? 1 : speed;
+    this.filterData.timescale.pitch = this.filters.vaporwave ? 1 : pitch;
+    this.filterData.timescale.rate = this.filters.vaporwave ? 1 : rate;
 
-      this.filters.vaporwave = !this.filters.vaporwave;
-      this.filters.nightcore = false;
-      this.filters.custom = false;
-      await this.updatePlayerFilters();
-      return this.filters.vaporwave;
+    this.filters.vaporwave = !this.filters.vaporwave;
+    this.filters.nightcore = false;
+    this.filters.custom = false;
+    await this.updatePlayerFilters();
+    return this.filters.vaporwave;
   }
   /**
    * Enable / Disables a Karaoke like Filter Effect
-   * @param level 
-   * @param monoLevel 
-   * @param filterBand 
-   * @param filterWidth 
-   * @returns 
+   * @param level
+   * @param monoLevel
+   * @param filterBand
+   * @param filterWidth
+   * @returns
    */
-  public async toggleKaraoke(level = 1, monoLevel = 1, filterBand = 220, filterWidth = 100): Promise<boolean> {
-      if(this.node.info && !this.node.info?.filters?.includes("karaoke")) throw new Error("Node#Info#filters does not include the 'karaoke' Filter (Node has it not enable)")
-    
-      this.filterData.karaoke.level = this.filters.karaoke ? 0 : level;
-      this.filterData.karaoke.monoLevel = this.filters.karaoke ? 0 : monoLevel;
-      this.filterData.karaoke.filterBand = this.filters.karaoke ? 0 : filterBand;
-      this.filterData.karaoke.filterWidth = this.filters.karaoke ? 0 : filterWidth;
+  public async toggleKaraoke(
+    level = 1,
+    monoLevel = 1,
+    filterBand = 220,
+    filterWidth = 100
+  ): Promise<boolean> {
+    if (this.node.info && !this.node.info?.filters?.includes("karaoke"))
+      throw new Error(
+        "Node#Info#filters does not include the 'karaoke' Filter (Node has it not enable)"
+      );
 
-      this.filters.karaoke = !this.filters.karaoke;
-      await this.updatePlayerFilters();
-      return this.filters.karaoke;
+    this.filterData.karaoke.level = this.filters.karaoke ? 0 : level;
+    this.filterData.karaoke.monoLevel = this.filters.karaoke ? 0 : monoLevel;
+    this.filterData.karaoke.filterBand = this.filters.karaoke ? 0 : filterBand;
+    this.filterData.karaoke.filterWidth = this.filters.karaoke
+      ? 0
+      : filterWidth;
+
+    this.filters.karaoke = !this.filters.karaoke;
+    await this.updatePlayerFilters();
+    return this.filters.karaoke;
   }
 
   /** Function to find out if currently there is a custom timescamle etc. filter applied */
   public isCustomFilterActive(): boolean {
-    this.filters.custom = !this.filters.nightcore && !this.filters.vaporwave && Object.values(this.filterData.timescale).some(d => d !== 1);
+    this.filters.custom =
+      !this.filters.nightcore &&
+      !this.filters.vaporwave &&
+      Object.values(this.filterData.timescale).some((d) => d !== 1);
     return this.filters.custom;
   }
   // function to update all filters at ONCE (and eqs)
   async updatePlayerFilters(): Promise<Player> {
     const sendData = { ...this.filterData };
 
-    if(!this.filters.volume) delete sendData.volume;
-    if(!this.filters.tremolo) delete sendData.tremolo;
-    if(!this.filters.vibrato) delete sendData.vibrato;
+    if (!this.filters.volume) delete sendData.volume;
+    if (!this.filters.tremolo) delete sendData.tremolo;
+    if (!this.filters.vibrato) delete sendData.vibrato;
     //if(!this.filters.karaoke) delete sendData.karaoke;
-    if(!this.filters.echo) delete sendData.echo;
-    if(!this.filters.reverb) delete sendData.reverb;
-    if(!this.filters.lowPass) delete sendData.lowPass;
-    if(!this.filters.karaoke) delete sendData.karaoke;
+    if (!this.filters.echo) delete sendData.echo;
+    if (!this.filters.reverb) delete sendData.reverb;
+    if (!this.filters.lowPass) delete sendData.lowPass;
+    if (!this.filters.karaoke) delete sendData.karaoke;
     //if(!this.filters.rotating) delete sendData.rotating;
-    if(this.filters.audioOutput === "stereo") delete sendData.channelMix;
+    if (this.filters.audioOutput === "stereo") delete sendData.channelMix;
     const now = Date.now();
-    if(!this.node.sessionId) {
-      if(sendData.rotation) {
+    if (!this.node.sessionId) {
+      if (sendData.rotation) {
         // @ts-ignore
-        sendData.rotating = sendData.rotation; 
+        sendData.rotating = sendData.rotation;
         delete sendData.rotation;
       } // on websocket it's called rotating, and on rest it's called rotation
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#updatePlayerFilters)");
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#updatePlayerFilters)"
+      );
       await this.node.send({
         op: "filters",
         guildId: this.guild,
         equalizer: this.bands.map((gain, band) => ({ band, gain })),
-        ...sendData
+        ...sendData,
       });
     } else {
       sendData.equalizer = this.bands.map((gain, band) => ({ band, gain }));
-      for(const key of [...Object.keys(sendData)]) {
-        if(this.node.info && !this.node.info?.filters?.includes?.(key)) delete sendData[key];
+      for (const key of [...Object.keys(sendData)]) {
+        if (this.node.info && !this.node.info?.filters?.includes?.(key))
+          delete sendData[key];
       }
       await this.node.updatePlayer({
         guildId: this.guild,
         playerOptions: {
           filters: sendData,
-        }
-      })
+        },
+      });
     }
     this.ping = Date.now() - now;
-    if(this.options.instaUpdateFiltersFix === true) this.filterUpdated = 1;
+    if (this.options.instaUpdateFiltersFix === true) this.filterUpdated = 1;
     return this;
   }
   /**
@@ -684,7 +791,7 @@ export class Player {
    */
   public search(
     query: string | SearchQuery,
-    requester?: unknown
+    requester?: string
   ): Promise<SearchResult> {
     return this.manager.search(query, requester, this.node);
   }
@@ -695,14 +802,23 @@ export class Player {
    */
   public async setEQ(...bands: EqualizerBand[]): Promise<this> {
     // Hacky support for providing an array
-    if (Array.isArray(bands[0])) bands = bands[0] as unknown as EqualizerBand[]
+    if (Array.isArray(bands[0])) bands = bands[0] as unknown as EqualizerBand[];
 
-    if (!bands.length || !bands.every((band) => JSON.stringify(Object.keys(band).sort()) === '["band","gain"]'))
-      throw new TypeError("Bands must be a non-empty object array containing 'band' and 'gain' properties.");
+    if (
+      !bands.length ||
+      !bands.every(
+        (band) => JSON.stringify(Object.keys(band).sort()) === '["band","gain"]'
+      )
+    )
+      throw new TypeError(
+        "Bands must be a non-empty object array containing 'band' and 'gain' properties."
+      );
 
     for (const { band, gain } of bands) this.bands[band] = gain;
-    if(!this.node.sessionId) {
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#setEQ)");
+    if (!this.node.sessionId) {
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#setEQ)"
+      );
       await this.node.send({
         op: "filters",
         guildId: this.guild,
@@ -712,9 +828,11 @@ export class Player {
       await this.node.updatePlayer({
         guildId: this.guild,
         playerOptions: {
-          filters: { equalizer: this.bands.map((gain, band) => ({ band, gain })) }
-        }
-      })
+          filters: {
+            equalizer: this.bands.map((gain, band) => ({ band, gain })),
+          },
+        },
+      });
     }
     return this;
   }
@@ -722,8 +840,10 @@ export class Player {
   /** Clears the equalizer bands. */
   public async clearEQ(): Promise<this> {
     this.bands = new Array(15).fill(0.0);
-    if(!this.node.sessionId) {
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#clearEQ)");
+    if (!this.node.sessionId) {
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#clearEQ)"
+      );
       await this.node.send({
         op: "filters",
         guildId: this.guild,
@@ -733,9 +853,11 @@ export class Player {
       await this.node.updatePlayer({
         guildId: this.guild,
         playerOptions: {
-          filters: { equalizer: this.bands.map((gain, band) => ({ band, gain })) }
-        }
-      })
+          filters: {
+            equalizer: this.bands.map((gain, band) => ({ band, gain })),
+          },
+        },
+      });
     }
     return this;
   }
@@ -839,7 +961,10 @@ export class Player {
    * @param track
    * @param options
    */
-  public async play(track: Track | UnresolvedTrack, options: PlayOptions): Promise<void>;
+  public async play(
+    track: Track | UnresolvedTrack,
+    options: PlayOptions
+  ): Promise<void>;
   public async play(
     optionsOrTrack?: PlayOptions | Track | UnresolvedTrack,
     playOptions?: PlayOptions
@@ -850,15 +975,23 @@ export class Player {
     ) {
       if (this.queue.current) this.queue.previous = this.queue.current;
       this.queue.current = optionsOrTrack as Track;
-    } 
+    }
 
     if (!this.queue.current) throw new RangeError("No current track.");
 
-    const finalOptions = getOptions(playOptions || optionsOrTrack, !!this.node.sessionId) ? (optionsOrTrack as PlayOptions) : {};
+    const finalOptions = getOptions(
+      playOptions || optionsOrTrack,
+      !!this.node.sessionId
+    )
+      ? (optionsOrTrack as PlayOptions)
+      : {};
 
     if (TrackUtils.isUnresolvedTrack(this.queue.current)) {
       try {
-        this.queue.current = await TrackUtils.getClosestTrack(this.queue.current as UnresolvedTrack, this.node);
+        this.queue.current = await TrackUtils.getClosestTrack(
+          this.queue.current as UnresolvedTrack,
+          this.node
+        );
       } catch (error) {
         this.manager.emit("trackError", this, this.queue.current, error);
         if (this.queue[0]) return this.play(this.queue[0]);
@@ -876,30 +1009,33 @@ export class Player {
       options.encodedTrack = (options.encodedTrack as Track).track;
     }
     if (typeof options.volume === "number" && !isNaN(options.volume)) {
-        this.volume = Math.max(Math.min(options.volume, 500), 0);
-        let vol = Number(this.volume);
-        if (this.manager.options.volumeDecrementer) vol *= this.manager.options.volumeDecrementer;
-        this.lavalinkVolume = Math.floor(vol * 100) / 100;
-        options.volume = vol;
+      this.volume = Math.max(Math.min(options.volume, 500), 0);
+      let vol = Number(this.volume);
+      if (this.manager.options.volumeDecrementer)
+        vol *= this.manager.options.volumeDecrementer;
+      this.lavalinkVolume = Math.floor(vol * 100) / 100;
+      options.volume = vol;
     }
 
     this.set("lastposition", this.position);
 
     const now = Date.now();
-    if(!this.node.sessionId) {
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#play)");
+    if (!this.node.sessionId) {
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#play)"
+      );
       await this.node.send({
         track: options.encodedTrack,
         op: "play",
         guildId: this.guild,
-        ...finalOptions
+        ...finalOptions,
       });
     } else {
       await this.node.updatePlayer({
         guildId: this.guild,
         noReplace: finalOptions.noReplace ?? false,
         playerOptions: options,
-      })
+      });
     }
     this.ping = Date.now() - now;
     return;
@@ -914,47 +1050,53 @@ export class Player {
 
     if (isNaN(volume)) throw new TypeError("Volume must be a number.");
     this.volume = Math.max(Math.min(volume, 500), 0);
-    
+
     let vol = Number(this.volume);
-    if(this.manager.options.volumeDecrementer) vol *= this.manager.options.volumeDecrementer;
+    if (this.manager.options.volumeDecrementer)
+      vol *= this.manager.options.volumeDecrementer;
 
     this.lavalinkVolume = Math.floor(vol * 100) / 100;
 
     const now = Date.now();
-    if(!this.node.sessionId) {
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#setVolume)");
+    if (!this.node.sessionId) {
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#setVolume)"
+      );
       await this.node.send({
         op: "volume",
         guildId: this.guild,
         volume: vol,
       });
     } else {
-      if(this.manager.options.applyVolumeAsFilter) {
+      if (this.manager.options.applyVolumeAsFilter) {
         await this.node.updatePlayer({
           guildId: this.guild,
           playerOptions: {
-            filters: { volume: vol / 100 }
-          }
+            filters: { volume: vol / 100 },
+          },
         });
       } else {
         await this.node.updatePlayer({
           guildId: this.guild,
           playerOptions: {
-            volume: vol
-          }
+            volume: vol,
+          },
         });
       }
     }
     this.ping = Date.now() - now;
     return this;
   }
-  
+
   /**
    * Applies a Node-Filter for Volume (make it louder/quieter without distortion | only for new REST api).
    * @param volume 0-5
    */
   public async setVolumeFilter(volume: number): Promise<this> {
-    if(!this.node.sessionId) throw new Error("The Lavalink-Node is either not ready, or not up to date! (REST Api must be useable)");
+    if (!this.node.sessionId)
+      throw new Error(
+        "The Lavalink-Node is either not ready, or not up to date! (REST Api must be useable)"
+      );
     volume = Number(volume);
 
     if (isNaN(volume)) throw new TypeError("Volume must be a number.");
@@ -965,8 +1107,8 @@ export class Player {
     await this.node.updatePlayer({
       guildId: this.guild,
       playerOptions: {
-        filters: { volume: this.filterData.volume }
-      }
+        filters: { volume: this.filterData.volume },
+      },
     });
     this.ping = Date.now() - now;
     return this;
@@ -1013,13 +1155,16 @@ export class Player {
   /** Stops the current track, optionally give an amount to skip to, e.g 5 would play the 5th song. */
   public async stop(amount?: number): Promise<this> {
     if (typeof amount === "number" && amount > 1) {
-      if (amount > this.queue.length) throw new RangeError("Cannot skip more than the queue length.");
+      if (amount > this.queue.length)
+        throw new RangeError("Cannot skip more than the queue length.");
       this.queue.splice(0, amount - 1);
     }
 
     const now = Date.now();
-    if(!this.node.sessionId) {
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#stop)");
+    if (!this.node.sessionId) {
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#stop)"
+      );
       await this.node.send({
         op: "stop",
         guildId: this.guild,
@@ -1027,7 +1172,7 @@ export class Player {
     } else {
       await this.node.updatePlayer({
         guildId: this.guild,
-        playerOptions: { encodedTrack: null }
+        playerOptions: { encodedTrack: null },
       });
     }
     this.ping = Date.now() - now;
@@ -1050,9 +1195,11 @@ export class Player {
     this.paused = paused;
 
     const now = Date.now();
-    
-    if(!this.node.sessionId) {
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#pause)");
+
+    if (!this.node.sessionId) {
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#pause)"
+      );
       await this.node.send({
         op: "pause",
         guildId: this.guild,
@@ -1088,9 +1235,11 @@ export class Player {
     this.set("lastposition", this.position);
 
     const now = Date.now();
-    
-    if(!this.node.sessionId) {
-      console.warn("@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#seek)");
+
+    if (!this.node.sessionId) {
+      console.warn(
+        "@deprecated - The Lavalink-Node is either not up to date (or not ready)! -- Using WEBSOCKET instead of REST (player#seek)"
+      );
       await this.node.send({
         op: "seek",
         guildId: this.guild,
@@ -1099,8 +1248,8 @@ export class Player {
     } else {
       await this.node.updatePlayer({
         guildId: this.guild,
-        playerOptions: { position }
-      })
+        playerOptions: { position },
+      });
     }
     this.ping = Date.now() - now;
     return this;
@@ -1208,14 +1357,27 @@ export interface EqualizerBand {
   gain: number;
 }
 
-function getOptions(opts?:any, allowFilters?: boolean): Partial<PlayOptions> | false {
-  const valids = ["startTime", "endTime", "noReplace", "volume", "pause", "filters"];
-  const returnObject = {} as PlayOptions
-  if(!opts) return false;
-  for(const [key, value] of Object.entries(Object.assign({}, opts))) {
-      if(valids.includes(key) && (key !== "filters" || (key === "filters" && allowFilters))) {
-        returnObject[key] = value
-      }
+function getOptions(
+  opts?: any,
+  allowFilters?: boolean
+): Partial<PlayOptions> | false {
+  const valids = [
+    "startTime",
+    "endTime",
+    "noReplace",
+    "volume",
+    "pause",
+    "filters",
+  ];
+  const returnObject = {} as PlayOptions;
+  if (!opts) return false;
+  for (const [key, value] of Object.entries(Object.assign({}, opts))) {
+    if (
+      valids.includes(key) &&
+      (key !== "filters" || (key === "filters" && allowFilters))
+    ) {
+      returnObject[key] = value;
+    }
   }
   return returnObject as PlayOptions;
 }

--- a/src/structures/Utils.ts
+++ b/src/structures/Utils.ts
@@ -434,7 +434,7 @@ export interface LavalinkPlayerVoice {
   ping?: number
 }
 
-export interface LavalinkPlayerVoiceOptions extends Omit<LavalinkPlayerVoice, 'connected'|'ping'> {}
+export type LavalinkPlayerVoiceOptions = Omit<LavalinkPlayerVoice, 'connected'|'ping'>
 
 export interface PlayerUpdateOptions {
   encodedTrack?: string|null;


### PR DESCRIPTION
Hello Tomato6966 in this Pull Request I changed the typing of the Music Requester in the Search method of the Player with the purpose of being defined the id of the user instead of the object of the user as a whole so I see a performance gain in the sense of less memory being used
and I added an interface to the manager events, so the user who has an EventHandler to start the Event in a separate file can get the name of the events more easily using the interface
here's how I created my Bot's [EventHandler](https://github.com/NedcloarBR/N-D-B/blob/master/Packages/Client/Src/Utils/Handlers/EventHandler.ts) that uses the [BaseEvent](https://github.com/NedcloarBR/N-D-B/blob/master/Packages/Client/Src/Utils/Structures/BaseEvent.ts) to validate the Event which in turn uses the event [interfaces](https://github.com/NedcloarBR/N-D-B/blob/master/Packages/Client/Src/Types/client.d.ts#L78-L88) to validate the names of the Events
In the end this PR stuck in improving the quality of life of the developer who uses your fork of Erela.js

Some code changes was my IDE using ESLint to "fix" the code




